### PR TITLE
link to javadoc updated

### DIFF
--- a/src/main/jbake/content/jaxrs002.adoc
+++ b/src/main/jbake/content/jaxrs002.adoc
@@ -52,7 +52,7 @@ the archive to a Jakarta EE server.
 link:#GINNA[Table 30-1] lists some of the Java programming annotations
 that are defined by JAX-RS, with a brief description of how each is
 used. Further information on the JAX-RS APIs can be viewed at
-`http://docs.oracle.com/javaee/7/api/`.
+`https://javaee.github.io/javaee-spec/javadocs/`.
 
 [[sthref137]][[GINNA]]
 


### PR DESCRIPTION
I'm not sure where is this right link. But old one is pointing to javaEE 7