### PR TITLE
First pass at JMS

### DIFF
--- a/src/main/jbake/content/jms-concepts.adoc
+++ b/src/main/jbake/content/jms-concepts.adoc
@@ -11,7 +11,7 @@ prev=partmessaging.html
 [[BNCDQ]][[java-message-service-concepts]]
 
 48 Jakarta Messaging Concepts
---------------------------------
+-----------------------------
 
 
 This chapter provides an introduction to Jakarta Messaging, 

--- a/src/main/jbake/content/jms-concepts.adoc
+++ b/src/main/jbake/content/jms-concepts.adoc
@@ -1,30 +1,30 @@
 type=page
 status=published
-title=Java Message Service Concepts
+title=Jakarta Messaging Concepts
 next=jms-concepts001.html
 prev=partmessaging.html
 ~~~~~~
-= Java Message Service Concepts
-:description: Java message service allows applications to create, send, and receive messages.
-:keywords: jms, glassfish
+= Jakarta Messaging Concepts
+:description: Jakarta Messaging allows applications to create, send, and receive messages.
+:keywords: messaging, glassfish
 
 [[BNCDQ]][[java-message-service-concepts]]
 
-48 Java Message Service Concepts
+48 Jakarta Messaging Concepts
 --------------------------------
 
 
-This chapter provides an introduction to the Java Message Service (JMS)
-API, a Java API that allows applications to create, send, receive, and
+This chapter provides an introduction to Jakarta Messaging, 
+a Java API that allows applications to create, send, receive, and
 read messages using reliable, asynchronous, loosely coupled
 communication.
 
 The following topics are addressed here:
 
-* link:jms-concepts001.html#BNCDR[Overview of the JMS API]
-* link:jms-concepts002.html#BNCDX[Basic JMS API Concepts]
-* link:jms-concepts003.html#BNCEH[The JMS API Programming Model]
-* link:jms-concepts004.html#BNCFU[Using Advanced JMS Features]
-* link:jms-concepts005.html#BNCGL[Using the JMS API in Jakarta EE
+* link:jms-concepts001.html#BNCDR[Jakarta Messaging Overview]
+* link:jms-concepts002.html#BNCDX[Basic Jakarta Messaging Concepts]
+* link:jms-concepts003.html#BNCEH[Jakarta Messaging Programming Model]
+* link:jms-concepts004.html#BNCFU[Using Advanced Jakarta Messaging Features]
+* link:jms-concepts005.html#BNCGL[Using Jakarta Messaging in Jakarta EE
 Applications]
-* link:jms-concepts006.html#BNCGU[Further Information about JMS]
+* link:jms-concepts006.html#BNCGU[Further Information about Jakarta Messaging]

--- a/src/main/jbake/content/jms-concepts001.adoc
+++ b/src/main/jbake/content/jms-concepts001.adoc
@@ -5,12 +5,12 @@ next=jms-concepts002.html
 prev=jms-concepts.html
 ~~~~~~
 Jakarta Messaging Overview
-=======================
+==========================
 
 [[BNCDR]][[overview-of-the-jms-api]]
 
 Jakarta Messaging Overview
------------------------
+--------------------------
 
 This overview defines the concept of messaging, describes Jakarta Messaging
 and where it can be used, and explains how Jakarta Messaging works within the
@@ -55,7 +55,7 @@ applications or software components.
 [[BNCDT]][[what-is-the-jms-api]]
 
 What Is Jakarta Messaging?
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Jakarta Messaging is a Java API that allows applications to
 create, send, receive, and read messages. Jakarta Messaging defines a common
@@ -84,7 +84,7 @@ The current version of the Jakarta Messaging specification is Version 2.0.
 [[BNCDU]][[when-can-you-use-the-jms-api]]
 
 When Can You Use Jakarta Messaging?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An enterprise application provider is likely to choose a messaging API
 over a tightly coupled API, such as a remote procedure call (RPC), under
@@ -131,7 +131,7 @@ services applications, and many others can make use of messaging.
 [[BNCDW]][[how-does-the-jms-api-work-with-the-jakarta-ee-platform]]
 
 How Does Jakarta Messaging Work with the Jakarta EE Platform?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When JMS was first introduced, its most important purpose was to
 allow Java applications to access existing messaging-oriented middleware

--- a/src/main/jbake/content/jms-concepts001.adoc
+++ b/src/main/jbake/content/jms-concepts001.adoc
@@ -1,27 +1,27 @@
 type=page
 status=published
-title=Overview of the JMS API
+title=Jakarta Messaging Overview
 next=jms-concepts002.html
 prev=jms-concepts.html
 ~~~~~~
-Overview of the JMS API
+Jakarta Messaging Overview
 =======================
 
 [[BNCDR]][[overview-of-the-jms-api]]
 
-Overview of the JMS API
+Jakarta Messaging Overview
 -----------------------
 
-This overview defines the concept of messaging, describes the JMS API
-and where it can be used, and explains how the JMS API works within the
+This overview defines the concept of messaging, describes Jakarta Messaging
+and where it can be used, and explains how Jakarta Messaging works within the
 Jakarta EE platform.
 
 The following topics are addressed here:
 
 * link:#BNCDS[What Is Messaging?]
-* link:#BNCDT[What Is the JMS API?]
-* link:#BNCDU[When Can You Use the JMS API?]
-* link:#BNCDW[How Does the JMS API Work with the Jakarta EE Platform?]
+* link:#BNCDT[What Is Jakarta Messaging?]
+* link:#BNCDU[When Can You Use Jakarta Messaging?]
+* link:#BNCDW[How Does Jakarta Messaging Work with the Jakarta EE Platform?]
 
 [[BNCDS]][[what-is-messaging]]
 
@@ -54,38 +54,36 @@ applications or software components.
 
 [[BNCDT]][[what-is-the-jms-api]]
 
-What Is the JMS API?
+What Is Jakarta Messaging?
 ~~~~~~~~~~~~~~~~~~~~
 
-The Java Message Service is a Java API that allows applications to
-create, send, receive, and read messages. The JMS API defines a common
+Jakarta Messaging is a Java API that allows applications to
+create, send, receive, and read messages. Jakarta Messaging defines a common
 set of interfaces and associated semantics that allow programs written
 in the Java programming language to communicate with other messaging
 implementations.
 
-The JMS API minimizes the set of concepts a programmer must learn in
+Jakarta Messaging minimizes the set of concepts a programmer must learn in
 order to use messaging products but provides enough features to support
 sophisticated messaging applications. It also strives to maximize the
-portability of JMS applications across JMS providers.
+portability of Messaging applications across providers.
 
-JMS enables communication that is not only loosely coupled but also
+Jakarta Messaging enables communication that is not only loosely coupled but also
 
 * Asynchronous: A receiving client does not have to receive messages at
 the same time the sending client sends them. The sending client can send
 them and go on to other tasks; the receiving client can receive them
 much later.
-* Reliable: A messaging provider that implements the JMS API can ensure
+* Reliable: A messaging provider that implements Jakarta Messaging can ensure
 that a message is delivered once and only once. Lower levels of
 reliability are available for applications that can afford to miss
 messages or to receive duplicate messages.
 
-The current version of the JMS specification is Version 2.0. You can
-download a copy of the specification from the Java Community Process
-website: `http://www.jcp.org/en/jsr/detail?id=343`.
+The current version of the Jakarta Messaging specification is Version 2.0.
 
 [[BNCDU]][[when-can-you-use-the-jms-api]]
 
-When Can You Use the JMS API?
+When Can You Use Jakarta Messaging?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An enterprise application provider is likely to choose a messaging API
@@ -101,7 +99,7 @@ to another and to continue to operate without receiving an immediate
 response.
 
 For example, components of an enterprise application for an automobile
-manufacturer can use the JMS API in situations like the following.
+manufacturer can use Jakarta Messaging in situations like the following.
 
 * The inventory component can send a message to the factory component
 when the inventory level for a product goes below a certain level so the
@@ -126,53 +124,52 @@ might work.
 image:img/jakartaeett_dt_026.png[
 "Diagram showing messaging between various departments in an enterprise"]
 
-Manufacturing is only one example of how an enterprise can use the JMS
+Manufacturing is only one example of how an enterprise can use the Jakarta Messaging
 API. Retail applications, financial services applications, health
 services applications, and many others can make use of messaging.
 
 [[BNCDW]][[how-does-the-jms-api-work-with-the-jakarta-ee-platform]]
 
-How Does the JMS API Work with the Jakarta EE Platform?
+How Does Jakarta Messaging Work with the Jakarta EE Platform?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When the JMS API was first introduced, its most important purpose was to
+When JMS was first introduced, its most important purpose was to
 allow Java applications to access existing messaging-oriented middleware
 (MOM) systems. Since that time, many vendors have adopted and
-implemented the JMS API, so a JMS product can now provide a complete
+implemented JMS, so a Jakarta Messaging product can now provide a complete
 messaging capability for an enterprise.
 
-The JMS API is an integral part of the Jakarta EE platform, and application
-developers can use messaging with Jakarta EE components. JMS 2.0 is part of
+Jakarta Messaging is an integral part of the Jakarta EE platform, and application
+developers can use messaging with Jakarta EE components. Jakarta Messaging 2.0 is part of
 the Jakarta EE 8 release.
 
-The JMS API in the Jakarta EE platform has the following features.
+Jakarta Messaging in the Jakarta EE platform has the following features.
 
-* Application clients, Enterprise JavaBeans (EJB) components, and web
-components can send or synchronously receive a JMS message. Application
-clients can in addition set a message listener that allows JMS messages
+* Application clients, Jakarta Enterprise Beans components, and web
+components can send or synchronously receive a Jakarta Messaging message. Application
+clients can in addition set a message listener that allows Jakarta Messaging messages
 to be delivered to it asynchronously by being notified when a message is
 available.
 * Message-driven beans, which are a kind of enterprise bean, enable the
-asynchronous consumption of messages in the EJB container. An
+asynchronous consumption of messages in the enterprise bean container. An
 application server typically pools message-driven beans to implement
 concurrent processing of messages.
-* Message send and receive operations can participate in Java
-Transaction API (JTA) transactions, which allow JMS operations and
-database accesses to take place within a single transaction.
+* Message send and receive operations can participate in Jakarta transactions,
+ which allow Jakarta Messaging operations and database accesses to take place within a single transaction.
 
-The JMS API enhances the other parts of the Jakarta EE platform by
+Jakarta Messaging enhances the other parts of the Jakarta EE platform by
 simplifying enterprise development, allowing loosely coupled, reliable,
 asynchronous interactions among Jakarta EE components and legacy systems
-capable of messaging. A developer can easily add new behavior to a Java
+capable of messaging. A developer can easily add new behavior to a Jakarta
 EE application that has existing business events by adding a new
 message-driven bean to operate on specific business events. The Jakarta EE
-platform, moreover, enhances the JMS API by providing support for JTA
-transactions and allowing for the concurrent consumption of messages.
-For more information, see the Enterprise JavaBeans specification, v3.2.
+platform, moreover, enhances Jakarta Messaging by providing support for Jakarta Transactions
+and allowing for the concurrent consumption of messages.
+For more information, see the Jakarta Enterprise Beans specification, v3.2.
 
-The JMS provider can be integrated with the application server using the
-Jakarta EE Connector architecture. You access the JMS provider through a
-resource adapter. This capability allows vendors to create JMS providers
+The Jakarta Messaging provider can be integrated with the application server using the
+Jakarta EE Connector architecture. You access the Messaging provider through a
+resource adapter. This capability allows vendors to create Messaging providers
 that can be plugged in to multiple application servers, and it allows
-application servers to support multiple JMS providers. For more
+application servers to support multiple Messaging providers. For more
 information, see the Jakarta EE Connector architecture specification, v1.7.

--- a/src/main/jbake/content/jms-concepts002.adoc
+++ b/src/main/jbake/content/jms-concepts002.adoc
@@ -1,54 +1,54 @@
 type=page
 status=published
-title=Basic JMS API Concepts
+title=Basic Jakarta Messaging Concepts
 next=jms-concepts003.html
 prev=jms-concepts001.html
 ~~~~~~
-Basic JMS API Concepts
+Basic Jakarta Messaging Concepts
 ======================
 
 [[BNCDX]][[basic-jms-api-concepts]]
 
-Basic JMS API Concepts
+Basic Jakarta Messaging Concepts
 ----------------------
 
-This section introduces the most basic JMS API concepts, the ones you
+This section introduces the most basic Jakarta Messaging concepts, the ones you
 must know to get started writing simple application clients that use the
-JMS API.
+Jakarta Messaging.
 
-The next section introduces the JMS API programming model. Later
+The next section introduces the Jakarta Messaging programming model. Later
 sections cover more advanced concepts, including the ones you need in
 order to write applications that use message-driven beans.
 
 The following topics are addressed here:
 
-* link:#BNCDY[JMS API Architecture]
+* link:#BNCDY[Jakarta Messaging Architecture]
 * link:#BNCEA[Messaging Styles]
 * link:#BNCEG[Message Consumption]
 
 [[BNCDY]][[jms-api-architecture]]
 
-JMS API Architecture
+Jakarta Messaging Architecture
 ~~~~~~~~~~~~~~~~~~~~
 
-A JMS application is composed of the following parts.
+A Jakarta Messaging application is composed of the following parts.
 
-* A JMS provider is a messaging system that implements the JMS
+* A Jakarta Messaging provider is a messaging system that implements the Messaging
 interfaces and provides administrative and control features. An
 implementation of the Jakarta EE platform that supports the full profile
-includes a JMS provider.
-* JMS clients are the programs or components, written in the Java
+includes a Messaging provider.
+* Jakarta Messaging clients are the programs or components, written in the Java
 programming language, that produce and consume messages. Any Jakarta EE
-application component can act as a JMS client.
+application component can act as a Messaging client.
 +
-Java SE applications can also act as JMS clients; the Message Queue
+Java SE applications can also act as Jakarta Messaging clients; the Message Queue
 Developer's Guide for Java Clients in the GlassFish Server documentation
-(`https://javaee.github.io/glassfish/documentation`) explains how to make this work.
-* Messages are the objects that communicate information between JMS
+(`https://eclipse-ee4j.github.io/glassfish/documentation`) explains how to make this work.
+* Messages are the objects that communicate information between Jakarta Messaging
 clients.
-* Administered objects are JMS objects configured for the use of
-clients. The two kinds of JMS administered objects are destinations and
-connection factories, described in link:jms-concepts003.html#BNCEJ[JMS
+* Administered objects are Jakarta Messaging objects configured for the use of
+clients. The two kinds of Jakarta Messaging administered objects are destinations and
+connection factories, described in link:jms-concepts003.html#BNCEJ[Jakarta Messaging
 Administered Objects]. An administrator can create objects that are
 available to all applications that use a particular installation of
 GlassFish Server; alternatively, a developer can use annotations to
@@ -56,15 +56,15 @@ create objects that are specific to a particular application.
 
 link:#BNCDZ[Figure 48-2] illustrates the way these parts interact.
 Administrative tools or annotations allow you to bind destinations and
-connection factories into a JNDI namespace. A JMS client can then use
+connection factories into a JNDI namespace. A Messaging client can then use
 resource injection to access the administered objects in the namespace
 and then establish a logical connection to the same objects through the
-JMS provider.
+Jakarta Messaging provider.
 
-[[BNCDZ]].*Figure 48-2 JMS API Architecture*
+[[BNCDZ]].*Figure 48-2 Jakarta Messaging Architecture*
 
 image:img/jakartaeett_dt_027.png[
-"Diagram of JMS API architecture, showing administrative tool, JMS
+"Diagram of Jakarta Messaging architecture, showing administrative tool, Jakarta Messaging
 client, JNDI namespace, and JMS provider"]
 
 [[BNCEA]][[messaging-styles]]
@@ -72,21 +72,21 @@ client, JNDI namespace, and JMS provider"]
 Messaging Styles
 ~~~~~~~~~~~~~~~~
 
-Before the JMS API existed, most messaging products supported either the
-point-to-point or the publish/subscribe style of messaging. The JMS
-specification defines compliance for each style. A JMS provider must
-implement both styles, and the JMS API provides interfaces that are
+Before the Jakarta Messaging existed, most messaging products supported either the
+point-to-point or the publish/subscribe style of messaging. The Jakarta Messaging
+specification defines compliance for each style. A Messaging provider must
+implement both styles, and the Jakarta Messaging provides interfaces that are
 specific to each. The following subsections describe these messaging
 styles.
 
-The JMS API, however, makes it unnecessary to use only one of the two
+Jakarta Messaging, however, makes it unnecessary to use only one of the two
 styles. It allows you to use the same code to send and receive messages
 using either the PTP or the pub/sub style. The destinations you use
 remain specific to one style, and the behavior of the application will
 depend in part on whether you are using a queue or a topic. However, the
 code itself can be common to both styles, making your applications
 flexible and reusable. This tutorial describes and illustrates this
-coding approach, using the greatly simplified API provided by JMS 2.0.
+coding approach, using the greatly simplified API provided by Jakarta Messaging 2.0.
 
 [[BNCEB]][[point-to-point-messaging-style]]
 
@@ -130,8 +130,8 @@ messages only as long as it takes to distribute them to subscribers.
 
 With pub/sub messaging, it is important to distinguish between the
 consumer that subscribes to a topic (the subscriber) and the
-subscription that is created. The consumer is a JMS object within an
-application, while the subscription is an entity within the JMS
+subscription that is created. The consumer is a Jakarta Messaging object within an
+application, while the subscription is an entity within the Jakarta Messaging
 provider. Normally, a topic can have many consumers, but a subscription
 has only one subscriber. It is possible, however, to create shared
 subscriptions; see link:jms-concepts003.html#BABJCIGJ[Creating Shared
@@ -146,7 +146,7 @@ Pub/sub messaging has the following characteristics.
 after the client has created a subscription, and the consumer must
 continue to be active in order for it to consume messages.
 +
-The JMS API relaxes this requirement to some extent by allowing
+The Jakarta Messaging relaxes this requirement to some extent by allowing
 applications to create durable subscriptions, which receive messages
 sent while the consumers are not active. Durable subscriptions provide
 the flexibility and reliability of queues but still allow clients to
@@ -173,7 +173,7 @@ Message Consumption
 
 Messaging products are inherently asynchronous: There is no fundamental
 timing dependency between the production and the consumption of a
-message. However, the JMS specification uses this term in a more precise
+message. However, the Jakarta Messaging specification uses this term in a more precise
 sense. Messages can be consumed in either of two ways.
 
 * Synchronously: A consumer explicitly fetches the message from the

--- a/src/main/jbake/content/jms-concepts002.adoc
+++ b/src/main/jbake/content/jms-concepts002.adoc
@@ -5,12 +5,12 @@ next=jms-concepts003.html
 prev=jms-concepts001.html
 ~~~~~~
 Basic Jakarta Messaging Concepts
-======================
+================================
 
 [[BNCDX]][[basic-jms-api-concepts]]
 
 Basic Jakarta Messaging Concepts
-----------------------
+--------------------------------
 
 This section introduces the most basic Jakarta Messaging concepts, the ones you
 must know to get started writing simple application clients that use the
@@ -29,7 +29,7 @@ The following topics are addressed here:
 [[BNCDY]][[jms-api-architecture]]
 
 Jakarta Messaging Architecture
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A Jakarta Messaging application is composed of the following parts.
 

--- a/src/main/jbake/content/jms-concepts003.adoc
+++ b/src/main/jbake/content/jms-concepts003.adoc
@@ -10,7 +10,7 @@ prev=jms-concepts002.html
 [[BNCEH]][[the-jms-api-programming-model]]
 
 Jakarta Messaging Programming Model
------------------------------
+-----------------------------------
 
 The basic building blocks of a Jakarta Messaging application are
 
@@ -50,7 +50,7 @@ of the Jakarta EE API documentation.
 [[BNCEJ]][[jms-administered-objects]]
 
 Jakarta Messaging Administered Objects
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Two parts of a Jakarta Messaging application, destinations and connection factories,
 are commonly maintained administratively rather than programmatically.
@@ -86,7 +86,7 @@ override those specified by annotations.
 [[BNCEK]][[jms-connection-factories]]
 
 Jakarta Messaging Connection Factories
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A connection factory is the object a client uses to create a connection
 to a provider. A connection factory encapsulates a set of connection
@@ -114,7 +114,7 @@ private static ConnectionFactory connectionFactory;
 [[BNCEL]][[jms-destinations]]
 
 Jakarta Messaging Destinations
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A destination is the object a client uses to specify the target of
 messages it produces and the source of messages it consumes. In the PTP
@@ -282,7 +282,7 @@ its work.
 [[BNCEO]][[jms-message-producers]]
 
 Jakarta Messaging Message Producers
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A message producer is an object that is created by a `JMSContext` or a
 session and used for sending messages to a destination. A message
@@ -314,7 +314,7 @@ Messages] for more information.
 [[BNCEP]][[jms-message-consumers]]
 
 Jakarta Messaging Message Consumers
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A message consumer is an object that is created by a `JMSContext` or a
 session and used for receiving messages sent to a destination. A message
@@ -377,7 +377,7 @@ link:#BABJCIGJ[Creating Shared Subscriptions].
 [[BNCEQ]][[jms-message-listeners]]
 
 Jakarta Messaging Message Listeners
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A message listener is an object that acts as an asynchronous event
 handler for messages. This object implements the `MessageListener`
@@ -420,7 +420,7 @@ and message-driven beans.
 [[BNCER]][[jms-message-selectors]]
 
 Jakarta Messaging Message Selectors
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If your messaging application needs to filter the messages it receives,
 you can use a Jakarta Messaging message selector, which allows a message consumer for
@@ -691,7 +691,7 @@ link:#BNCGD[Creating Durable Subscriptions].
 [[BNCES]][[jms-messages]]
 
 Jakarta Messaging Messages
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ultimate purpose of a Jakarta Messaging application is to produce and consume
 messages that can then be used by other software applications. Jakarta Messaging
@@ -918,7 +918,7 @@ and `Message`.
 [[BNCEY]][[jms-queue-browsers]]
 
 Jakarta Messaging Queue Browsers
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Messages sent to a queue remain in the queue until the message consumer
 for that queue consumes them. Jakarta Messaging provides a `QueueBrowser`
@@ -948,7 +948,7 @@ examining them.
 [[BNCEZ]][[jms-exception-handling]]
 
 Jakarta Messaging Exception Handling
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The root class for all checked exceptions in Jakarta Messaging is
 `JMSException`. The root cause for all unchecked exceptions in the Jakarta Messaging

--- a/src/main/jbake/content/jms-concepts003.adoc
+++ b/src/main/jbake/content/jms-concepts003.adoc
@@ -86,7 +86,7 @@ override those specified by annotations.
 [[BNCEK]][[jms-connection-factories]]
 
 Jakarta Messaging Connection Factories
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A connection factory is the object a client uses to create a connection
 to a provider. A connection factory encapsulates a set of connection
@@ -114,7 +114,7 @@ private static ConnectionFactory connectionFactory;
 [[BNCEL]][[jms-destinations]]
 
 Jakarta Messaging Destinations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A destination is the object a client uses to specify the target of
 messages it produces and the source of messages it consumes. In the PTP
@@ -377,7 +377,7 @@ link:#BABJCIGJ[Creating Shared Subscriptions].
 [[BNCEQ]][[jms-message-listeners]]
 
 Jakarta Messaging Message Listeners
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A message listener is an object that acts as an asynchronous event
 handler for messages. This object implements the `MessageListener`
@@ -420,7 +420,7 @@ and message-driven beans.
 [[BNCER]][[jms-message-selectors]]
 
 Jakarta Messaging Message Selectors
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If your messaging application needs to filter the messages it receives,
 you can use a Jakarta Messaging message selector, which allows a message consumer for

--- a/src/main/jbake/content/jms-concepts003.adoc
+++ b/src/main/jbake/content/jms-concepts003.adoc
@@ -1,18 +1,18 @@
 type=page
 status=published
-title=The JMS API Programming Model
+title=Jakarta Messaging Programming Model
 next=jms-concepts004.html
 prev=jms-concepts002.html
 ~~~~~~
-= The JMS API Programming Model
+= Jakarta Messaging Programming Model
 
 
 [[BNCEH]][[the-jms-api-programming-model]]
 
-The JMS API Programming Model
+Jakarta Messaging Programming Model
 -----------------------------
 
-The basic building blocks of a JMS application are
+The basic building blocks of a Jakarta Messaging application are
 
 * Administered objects: connection factories and destinations
 * Connections
@@ -24,55 +24,55 @@ object
 * Messages
 
 link:#BNCEI[Figure 48-5] shows how all these objects fit together in a
-JMS client application.
+Messaging client application.
 
 [[BNCEI]]
 
-.*Figure 48-5 The JMS API Programming Model*
+.*Figure 48-5 Jakarta Messaging Programming Model*
 image:img/jakartaeett_dt_030.png[
-"Diagram of the JMS API programming model: connection factory,
+"Diagram of Jakarta Messaging programming model: connection factory,
 JMSContext, connection, session, message producer, message consumer,
 messages, and destinations"]
 
-JMS also provides queue browsers, objects that allow an application to
+Jakarta Messaging also provides queue browsers, objects that allow an application to
 browse messages on a queue.
 
 This section describes all these objects briefly and provides sample
 commands and code snippets that show how to create and use the objects.
-The last subsection briefly describes JMS API exception handling.
+The last subsection briefly describes Jakarta Messaging API exception handling.
 
 Examples that show how to combine all these objects in applications
 appear in link:jms-examples.html#BNCGV[Chapter 49, "Java Message Service
 Examples,"] beginning with link:jms-examples003.html#BNCFA[Writing Simple
-JMS Applications]. For more detail, see the JMS API documentation, part
+Jakarta Messaging Applications]. For more detail, see Jakarta Messaging documentation, part
 of the Jakarta EE API documentation.
 
 [[BNCEJ]][[jms-administered-objects]]
 
-JMS Administered Objects
+Jakarta Messaging Administered Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Two parts of a JMS application, destinations and connection factories,
+Two parts of a Jakarta Messaging application, destinations and connection factories,
 are commonly maintained administratively rather than programmatically.
 The technology underlying these objects is likely to be very different
-from one implementation of the JMS API to another. Therefore, the
+from one implementation of Jakarta Messaging to another. Therefore, the
 management of these objects belongs with other administrative tasks that
 vary from provider to provider.
 
-JMS clients access administered objects through interfaces that are
+Messaging clients access administered objects through interfaces that are
 portable, so a client application can run with little or no change on
-more than one implementation of the JMS API. Ordinarily, an
+more than one implementation of Jakarta Messaging. Ordinarily, an
 administrator configures administered objects in a JNDI namespace, and
-JMS clients then access them by using resource injection.
+Messaging clients then access them by using resource injection.
 
 With GlassFish Server, you can use the `asadmin create-jms-resource`
-command or the Administration Console to create JMS administered objects
+command or the Administration Console to create Jakarta Messaging administered objects
 in the form of connector resources. You can also specify the resources
 in a file named `glassfish-resources.xml` that you can bundle with an
 application.
 
-NetBeans IDE provides a wizard that allows you to create JMS resources
-for GlassFish Server. See link:jms-examples003.html#GKTJS[Creating JMS
+NetBeans IDE provides a wizard that allows you to create Jakarta Messaging resources
+for GlassFish Server. See link:jms-examples003.html#GKTJS[Creating Jakarta Messaging
 Administered Objects] for details.
 
 The Jakarta EE platform specification allows a developer to create
@@ -85,7 +85,7 @@ override those specified by annotations.
 
 [[BNCEK]][[jms-connection-factories]]
 
-JMS Connection Factories
+Jakarta Messaging Connection Factories
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 A connection factory is the object a client uses to create a connection
@@ -94,15 +94,15 @@ configuration parameters that has been defined by an administrator. Each
 connection factory is an instance of the `ConnectionFactory`,
 `QueueConnectionFactory`, or `TopicConnectionFactory` interface. To
 learn how to create connection factories, see
-link:jms-examples003.html#GKTJS[Creating JMS Administered Objects].
+link:jms-examples003.html#GKTJS[Creating Jakarta Messaging Administered Objects].
 
-At the beginning of a JMS client program, you usually inject a
+At the beginning of a Messaging client program, you usually inject a
 connection factory resource into a `ConnectionFactory` object. A Jakarta EE
-server must provide a JMS connection factory with the logical JNDI name
+server must provide a Jakarta Messaging connection factory with the logical JNDI name
 `java:comp/DefaultJMSConnectionFactory`. The actual JNDI name will be
 implementation-specific.
 
-For example, the following code fragment looks up the default JMS
+For example, the following code fragment looks up the default Jakarta Messaging
 connection factory and assigns it to a `ConnectionFactory` object:
 
 [source,oac_no_warn]
@@ -113,21 +113,21 @@ private static ConnectionFactory connectionFactory;
 
 [[BNCEL]][[jms-destinations]]
 
-JMS Destinations
+Jakarta Messaging Destinations
 ^^^^^^^^^^^^^^^^
 
 A destination is the object a client uses to specify the target of
 messages it produces and the source of messages it consumes. In the PTP
 messaging style, destinations are called queues. In the pub/sub
-messaging style, destinations are called topics. A JMS application can
+messaging style, destinations are called topics. A Jakarta Messaging application can
 use multiple queues or topics (or both). To learn how to create
-destination resources, see link:jms-examples003.html#GKTJS[Creating JMS
+destination resources, see link:jms-examples003.html#GKTJS[Creating Jakarta Messaging
 Administered Objects].
 
-To create a destination using GlassFish Server, you create a JMS
+To create a destination using GlassFish Server, you create a Jakarta Messaging
 destination resource that specifies a JNDI name for the destination.
 
-In the GlassFish Server implementation of JMS, each destination resource
+In the GlassFish Server implementation of Jakarta Messaging, each destination resource
 refers to a physical destination. You can create a physical destination
 explicitly, but if you do not, the Application Server creates it when it
 is needed and deletes it when you delete the destination resource.
@@ -152,7 +152,7 @@ private static Queue queue;
 private static Topic topic;
 ----
 
-In a Jakarta EE application, JMS administered objects are normally placed
+In a Jakarta EE application, Jakarta Messaging administered objects are normally placed
 in the `jms` naming subcontext.
 
 With the common interfaces, you can mix or match connection factories
@@ -168,7 +168,7 @@ factory you use.
 Connections
 ~~~~~~~~~~~
 
-A connection encapsulates a virtual connection with a JMS provider. For
+A connection encapsulates a virtual connection with a Messaging provider. For
 example, a connection could represent an open TCP/IP socket between a
 client and a provider service daemon. You use a connection to create one
 or more sessions.
@@ -204,11 +204,11 @@ You use sessions to create message producers, message consumers,
 messages, queue browsers, and temporary destinations.
 
 Sessions serialize the execution of message listeners; for details, see
-link:#BNCEQ[JMS Message Listeners].
+link:#BNCEQ[Jakarta Messaging Message Listeners].
 
 A session provides a transactional context with which to group a set of
 sends and receives into an atomic unit of work. For details, see
-link:jms-concepts004.html#BNCGH[Using JMS Local Transactions].
+link:jms-concepts004.html#BNCGH[Using Jakarta Messaging Local Transactions].
 
 [[BABGDFEA]][[jmscontext-objects]]
 
@@ -216,7 +216,7 @@ JMSContext Objects
 ~~~~~~~~~~~~~~~~~~
 
 A `JMSContext` object combines a connection and a session in a single
-object. That is, it provides both an active connection to a JMS provider
+object. That is, it provides both an active connection to a Messaging provider
 and a single-threaded context for sending and receiving messages.
 
 You use the `JMSContext` to create the following objects:
@@ -245,8 +245,8 @@ non-transacted session with an acknowledgment mode of
 `JMSContext.AUTO_ACKNOWLEDGE`. When called with no arguments from the
 web or EJB container when there is an active JTA transaction in
 progress, the `createContext` method creates a transacted session. For
-information about the way JMS transactions work in Jakarta EE applications,
-see link:jms-concepts005.html#BNCGL[Using the JMS API in Jakarta EE
+information about the way Jakarta Messaging transactions work in Jakarta EE applications,
+see link:jms-concepts005.html#BNCGL[Using Jakarta Messaging in Jakarta EE
 Applications].
 
 From an application client or a Java SE client, you can also call the
@@ -260,7 +260,7 @@ JMSContext context =
 ----
 
 The session uses local transactions; see
-link:jms-concepts004.html#BNCGH[Using JMS Local Transactions] for
+link:jms-concepts004.html#BNCGH[Using Jakarta Messaging Local Transactions] for
 details.
 
 Alternatively, you can specify a non-default acknowledgment mode; see
@@ -268,12 +268,12 @@ link:jms-concepts004.html#BNCFW[Controlling Message Acknowledgment] for
 more information.
 
 When you use a `JMSContext`, message delivery normally begins as soon as
-you create a consumer. See link:#BNCEP[JMS Message Consumers] for more
+you create a consumer. See link:#BNCEP[Jakarta Messaging Message Consumers] for more
 information.
 
 If you create a `JMSContext` in a `try`-with-resources block, you do not
 need to close it explicitly. It will be closed when the `try` block
-comes to an end. Make sure that your application completes all its JMS
+comes to an end. Make sure that your application completes all its Jakarta Messaging
 activity within the `try`-with-resources block. If you do not use a
 `try`-with-resources block, you must call the `close` method on the
 `JMSContext` to close the connection when the application has finished
@@ -281,7 +281,7 @@ its work.
 
 [[BNCEO]][[jms-message-producers]]
 
-JMS Message Producers
+Jakarta Messaging Message Producers
 ~~~~~~~~~~~~~~~~~~~~~
 
 A message producer is an object that is created by a `JMSContext` or a
@@ -313,7 +313,7 @@ Messages] for more information.
 
 [[BNCEP]][[jms-message-consumers]]
 
-JMS Message Consumers
+Jakarta Messaging Message Consumers
 ~~~~~~~~~~~~~~~~~~~~~
 
 A message consumer is an object that is created by a `JMSContext` or a
@@ -329,8 +329,8 @@ try (JMSContext context = connectionFactory.createContext();) {
     ...
 ----
 
-A message consumer allows a JMS client to register interest in a
-destination with a JMS provider. The JMS provider manages the delivery
+A message consumer allows a Messaging client to register interest in a
+destination with a Messaging provider. The Jakarta Messaging provider manages the delivery
 of messages from a destination to the registered consumers of the
 destination.
 
@@ -376,7 +376,7 @@ link:#BABJCIGJ[Creating Shared Subscriptions].
 
 [[BNCEQ]][[jms-message-listeners]]
 
-JMS Message Listeners
+Jakarta Messaging Message Listeners
 ^^^^^^^^^^^^^^^^^^^^^
 
 A message listener is an object that acts as an asynchronous event
@@ -396,7 +396,7 @@ Listener myListener = new Listener();
 consumer.setMessageListener(myListener);
 ----
 
-When message delivery begins, the JMS provider automatically calls the
+When message delivery begins, the Messaging provider automatically calls the
 message listener's `onMessage` method whenever a message is delivered.
 The `onMessage` method takes one argument of type `Message`, which your
 implementation of the method can cast to another message subtype as
@@ -419,13 +419,13 @@ and message-driven beans.
 
 [[BNCER]][[jms-message-selectors]]
 
-JMS Message Selectors
+Jakarta Messaging Message Selectors
 ^^^^^^^^^^^^^^^^^^^^^
 
 If your messaging application needs to filter the messages it receives,
-you can use a JMS message selector, which allows a message consumer for
+you can use a Jakarta Messaging message selector, which allows a message consumer for
 a destination to specify the messages that interest it. Message
-selectors assign the work of filtering messages to the JMS provider
+selectors assign the work of filtering messages to the Messaging provider
 rather than to the application. For an example of an application that
 uses a message selector, see link:jms-examples008.html#BNCGW[Sending
 Messages from a Session Bean to an MDB].
@@ -463,8 +463,8 @@ on that topic and creating a consumer on that subscription.
 Subscriptions may be durable or nondurable, and they may be shared or
 unshared.
 
-A subscription may be thought of as an entity within the JMS provider
-itself, whereas a consumer is a JMS object within the application.
+A subscription may be thought of as an entity within the Messaging provider
+itself, whereas a consumer is a Jakarta Messaging object within the application.
 
 A subscription will receive a copy of every message that is sent to the
 topic after the subscription is created, unless a message selector is
@@ -474,7 +474,7 @@ properties match the message selector will be added to the subscription.
 Unshared subscriptions are restricted to a single consumer. In this
 case, all the messages in the subscription are delivered to that
 consumer. Shared subscriptions allow multiple consumers. In this case,
-each message in the subscription is delivered to only one consumer. JMS
+each message in the subscription is delivered to only one consumer. Jakarta Messaging
 does not define how messages are distributed between multiple consumers
 on the same subscription.
 
@@ -534,10 +534,10 @@ consumer on an unshared durable subscription. An unshared durable
 subscription can have only one active consumer at a time.
 
 A consumer identifies the durable subscription from which it consumes
-messages by specifying a unique identity that is retained by the JMS
+messages by specifying a unique identity that is retained by the Messaging
 provider. Subsequent consumer objects that have the same identity resume
 the subscription in the state in which it was left by the preceding
-consumer. If a durable subscription has no active consumer, the JMS
+consumer. If a durable subscription has no active consumer, the Messaging
 provider retains the subscription's messages until they are received by
 the subscription or until they expire.
 
@@ -570,11 +570,11 @@ you might close the consumer:
 consumer.close();
 ----
 
-The JMS provider stores the messages sent to the topic, as it would
+The Messaging provider stores the messages sent to the topic, as it would
 store messages sent to a queue. If the program or another application
 calls `createDurableConsumer` using the same connection factory and its
 client ID, the same topic, and the same subscription name, then the
-subscription is reactivated and the JMS provider delivers the messages
+subscription is reactivated and the Messaging provider delivers the messages
 that were sent while the subscription was inactive.
 
 To delete a durable subscription, first close the consumer, then call
@@ -690,16 +690,16 @@ link:#BNCGD[Creating Durable Subscriptions].
 
 [[BNCES]][[jms-messages]]
 
-JMS Messages
+Jakarta Messaging Messages
 ~~~~~~~~~~~~
 
-The ultimate purpose of a JMS application is to produce and consume
-messages that can then be used by other software applications. JMS
+The ultimate purpose of a Jakarta Messaging application is to produce and consume
+messages that can then be used by other software applications. Jakarta Messaging
 messages have a basic format that is simple but highly flexible,
-allowing you to create messages that match formats used by non-JMS
+allowing you to create messages that match formats used by non-Jakarta Messaging
 applications on heterogeneous platforms.
 
-A JMS message can have three parts: a header, properties, and a body.
+A Jakarta Messaging message can have three parts: a header, properties, and a body.
 Only the header is required. The following sections describe these
 parts.
 
@@ -719,9 +719,9 @@ The following topics are addressed here:
 Message Headers
 ^^^^^^^^^^^^^^^
 
-A JMS message header contains a number of predefined fields that contain
+A Jakarta Messaging message header contains a number of predefined fields that contain
 values used by both clients and providers to identify and route
-messages. link:#BNCEU[Table 48-1] lists and describes the JMS message
+messages. link:#BNCEU[Table 48-1] lists and describes the Jakarta Messaging message
 header fields and indicates how their values are set. For example, every
 message has a unique identifier, which is represented in the header
 field `JMSMessageID`. The value of another header field,
@@ -736,7 +736,7 @@ values.
 
 [[sthref196]][[BNCEU]]
 
-*Table 48-1 How JMS Message Header Field Values Are Set*
+*Table 48-1 How Jakarta Messaging Message Header Field Values Are Set*
 
 [width="99%",cols="20%,60%,20%"]
 |=======================================================================
@@ -746,7 +746,7 @@ provider `send` method
 
 |`JMSDeliveryMode` |Delivery mode specified when the message was sent
 (see link:jms-concepts004.html#BNCFY[Specifying Message Persistence])
-|JMS provider `send` method
+|Messaging provider `send` method
 
 |`JMSDeliveryTime` |The time the message was sent plus the delivery
 delay specified when the message was sent (see
@@ -758,14 +758,14 @@ link:jms-concepts004.html#BNCGA[Allowing Messages to Expire]) |JMS
 provider `send` method
 
 |`JMSPriority` |The priority of the message (see
-link:jms-concepts004.html#BNCFZ[Setting Message Priority Levels]) |JMS
+link:jms-concepts004.html#BNCFZ[Setting Message Priority Levels]) |Jakarta Messaging
 provider `send` method
 
 |`JMSMessageID` |Value that uniquely identifies each message sent by a
-provider |JMS provider `send` method
+provider |Messaging provider `send` method
 
 |`JMSTimestamp` |The time the message was handed off to a provider to be
-sent |JMS provider `send` method
+sent |Messaging provider `send` method
 
 |`JMSCorrelationID` |Value that links one message to another; commonly
 the `JMSMessageID` value is used |Client application
@@ -776,7 +776,7 @@ the `JMSMessageID` value is used |Client application
 |`JMSType` |Type identifier supplied by client application |Client
 application
 
-|`JMSRedelivered` |Whether the message is being redelivered |JMS
+|`JMSRedelivered` |Whether the message is being redelivered |Jakarta Messaging
 provider prior to delivery
 |=======================================================================
 
@@ -789,13 +789,13 @@ Message Properties
 You can create and set properties for messages if you need values in
 addition to those provided by the header fields. You can use properties
 to provide compatibility with other messaging systems, or you can use
-them to create message selectors (see link:#BNCER[JMS Message
+them to create message selectors (see link:#BNCER[Jakarta Messaging Message
 Selectors]). For an example of setting a property to be used as a
 message selector, see link:jms-examples008.html#BNCGW[Sending Messages
 from a Session Bean to an MDB].
 
-The JMS API provides some predefined property names that begin with
-`JMSX`. A JMS provider is required to implement only one of these,
+Jakarta Messaging provides some predefined property names that begin with
+`JMSX`. A Messaging provider is required to implement only one of these,
 `JMSXDeliveryCount` (which specifies the number of times a message has
 been delivered); the rest are optional. The use of these predefined
 properties or of user-defined properties in applications is optional.
@@ -805,14 +805,14 @@ properties or of user-defined properties in applications is optional.
 Message Bodies
 ^^^^^^^^^^^^^^
 
-The JMS API defines six different types of messages. Each message type
+Jakarta Messaging defines six different types of messages. Each message type
 corresponds to a different message body. These message types allow you
 to send and receive data in many different forms. link:#BNCEX[Table
 48-2] describes these message types.
 
 [[sthref197]][[BNCEX]]
 
-*Table 48-2 JMS Message Types*
+*Table 48-2 Jakarta Messaging Message Types*
 
 [width="75%",cols="15%,60%"]
 |=======================================================================
@@ -839,7 +839,7 @@ message type is useful when a message body is not required.
 |=======================================================================
 
 
-The JMS API provides methods for creating messages of each type and for
+Jakarta Messaging provides methods for creating messages of each type and for
 filling in their contents. For example, to create and send a
 `TextMessage`, you might use the following statements:
 
@@ -874,7 +874,7 @@ if (m instanceof TextMessage) {
 }
 ----
 
-The JMS API provides shortcuts for creating and receiving a
+Jakarta Messaging provides shortcuts for creating and receiving a
 `TextMessage`, `BytesMessage`, `MapMessage`, or `ObjectMessage`. For
 example, you do not have to wrap a string in a `TextMessage`; instead,
 you can send and receive the string directly. For example, you can send
@@ -899,7 +899,7 @@ can be assigned to a particular type.
 
 An empty `Message` can be useful if you want to send a message that is
 simply a signal to the application. Some of the examples in
-link:jms-examples.html#BNCGV[Chapter 49, "Java Message Service
+link:jms-examples.html#BNCGV[Chapter 49, "Jakarta Messaging
 Examples,"] send an empty message after sending a series of text
 messages. For example:
 
@@ -911,17 +911,17 @@ context.createProducer().send(dest, context.createMessage());
 The consumer code can then interpret a non-text message as a signal that
 all the messages sent have now been received.
 
-The examples in link:jms-examples.html#BNCGV[Chapter 49, "Java Message
-Service Examples,"] use messages of type `TextMessage`, `MapMessage`,
+The examples in link:jms-examples.html#BNCGV[Chapter 49, "Jakarta Messaging
+Examples,"] use messages of type `TextMessage`, `MapMessage`,
 and `Message`.
 
 [[BNCEY]][[jms-queue-browsers]]
 
-JMS Queue Browsers
+Jakarta Messaging Queue Browsers
 ~~~~~~~~~~~~~~~~~~
 
 Messages sent to a queue remain in the queue until the message consumer
-for that queue consumes them. The JMS API provides a `QueueBrowser`
+for that queue consumes them. Jakarta Messaging provides a `QueueBrowser`
 object that allows you to browse the messages in the queue and display
 the header values for each message. To create a `QueueBrowser` object,
 use the `JMSContext.createBrowser` method. For example:
@@ -936,26 +936,26 @@ example of using a `QueueBrowser` object.
 
 The `createBrowser` method allows you to specify a message selector as a
 second argument when you create a `QueueBrowser`. For information on
-message selectors, see link:#BNCER[JMS Message Selectors].
+message selectors, see link:#BNCER[Jakarta Messaging Message Selectors].
 
-The JMS API provides no mechanism for browsing a topic. Messages usually
+Jakarta Messaging provides no mechanism for browsing a topic. Messages usually
 disappear from a topic as soon as they appear: If there are no message
-consumers to consume them, the JMS provider removes them. Although
+consumers to consume them, the Messaging provider removes them. Although
 durable subscriptions allow messages to remain on a topic while the
-message consumer is not active, JMS does not define any facility for
+message consumer is not active, Jakarta Messaging does not define any facility for
 examining them.
 
 [[BNCEZ]][[jms-exception-handling]]
 
-JMS Exception Handling
+Jakarta Messaging Exception Handling
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The root class for all checked exceptions in the JMS API is
-`JMSException`. The root cause for all unchecked exceptions in the JMS
+The root class for all checked exceptions in Jakarta Messaging is
+`JMSException`. The root cause for all unchecked exceptions in the Jakarta Messaging
 API is `JMSRuntimeException`.
 
 Catching `JMSException` and `JMSRuntimeException` provides a generic way
-of handling all exceptions related to the JMS API.
+of handling all exceptions related to Jakarta Messaging.
 
 The `JMSException` and `JMSRuntimeException` classes include the
 following subclasses, described in the API documentation:

--- a/src/main/jbake/content/jms-concepts004.adoc
+++ b/src/main/jbake/content/jms-concepts004.adoc
@@ -1,29 +1,29 @@
 type=page
 status=published
-title=Using Advanced JMS Features
+title=Using Advanced Jakarta Messaging Features
 next=jms-concepts005.html
 prev=jms-concepts003.html
 ~~~~~~
-Using Advanced JMS Features
+Using Advanced Jakarta Messaging Features
 ===========================
 
 [[BNCFU]][[using-advanced-jms-features]]
 
-Using Advanced JMS Features
+Using Advanced Jakarta Messaging Features
 ---------------------------
 
-This section explains how to use features of the JMS API to achieve the
+This section explains how to use features of Jakarta Messaging to achieve the
 level of reliability and performance your application requires. Many
-people use JMS in their applications because they cannot tolerate
+people use Jakarta Messaging in their applications because they cannot tolerate
 dropped or duplicate messages and because they require that every
-message be received once and only once. The JMS API provides this
+message be received once and only once. Jakarta Messaging provides this
 functionality.
 
 The most reliable way to produce a message is to send a `PERSISTENT`
 message, and to do so within a transaction.
 
-JMS messages are `PERSISTENT` by default; `PERSISTENT` messages will not
-be lost in the event of JMS provider failure. For details, see
+Jakarta Messaging messages are `PERSISTENT` by default; `PERSISTENT` messages will not
+be lost in the event of Messaging provider failure. For details, see
 link:#BNCFY[Specifying Message Persistence].
 
 Transactions allow multiple messages to be sent or received in an atomic
@@ -32,13 +32,13 @@ receives to be combined with database reads and writes in an atomic
 transaction. A transaction is a unit of work into which you can group a
 series of operations, such as message sends and receives, so that the
 operations either all succeed or all fail. For details, see
-link:#BNCGH[Using JMS Local Transactions].
+link:#BNCGH[Using Jakarta Messaging Local Transactions].
 
 The most reliable way to consume a message is to do so within a
 transaction, either from a queue or from a durable subscription to a
 topic. For details, see link:jms-concepts003.html#BNCGD[Creating Durable
 Subscriptions], link:#BNCGB[Creating Temporary Destinations], and
-link:#BNCGH[Using JMS Local Transactions].
+link:#BNCGH[Using Jakarta Messaging Local Transactions].
 
 Some features primarily allow an application to improve performance. For
 example, you can set messages to expire after a certain length of time
@@ -56,9 +56,9 @@ link:#BNCGB[Creating Temporary Destinations] for details.
 
 The following sections describe these features as they apply to
 application clients or Java SE clients. Some of the features work
-differently in the Jakarta EE web or EJB container; in these cases, the
+differently in the Jakarta EE web or enterprise bean container; in these cases, the
 differences are noted here and are explained in detail in
-link:jms-concepts005.html#BNCGL[Using the JMS API in Jakarta EE
+link:jms-concepts005.html#BNCGL[Using Jakarta Messaging in Jakarta EE
 Applications].
 
 [[BNCFW]][[controlling-message-acknowledgment]]
@@ -66,21 +66,21 @@ Applications].
 Controlling Message Acknowledgment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Until a JMS message has been acknowledged, it is not considered to be
+Until a Jakarta Messaging message has been acknowledged, it is not considered to be
 successfully consumed. The successful consumption of a message
 ordinarily takes place in three stages.
 
 1.  The client receives the message.
 2.  The client processes the message.
 3.  The message is acknowledged. Acknowledgment is initiated either by
-the JMS provider or by the client, depending on the session
+the Messaging provider or by the client, depending on the session
 acknowledgment mode.
 
-In locally transacted sessions (see link:#BNCGH[Using JMS Local
+In locally transacted sessions (see link:#BNCGH[Using Jakarta Messaging Local
 Transactions]), a message is acknowledged when the session is committed.
 If a transaction is rolled back, all consumed messages are redelivered.
 
-In a JTA transaction (in the Jakarta EE web or EJB container) a message is
+In a Jakarta transaction (in the Jakarta EE web or enterprise bean container) a message is
 acknowledged when the transaction is committed.
 
 In nontransacted sessions, when and how a message is acknowledged depend
@@ -121,15 +121,15 @@ enterprise bean.
 
 * `JMSContext.DUPS_OK_ACKNOWLEDGE`: This option instructs the
 `JMSContext` to lazily acknowledge the delivery of messages. This is
-likely to result in the delivery of some duplicate messages if the JMS
+likely to result in the delivery of some duplicate messages if the Messaging
 provider fails, so it should be used only by consumers that can tolerate
-duplicate messages. (If the JMS provider redelivers a message, it must
+duplicate messages. (If the Messaging provider redelivers a message, it must
 set the value of the `JMSRedelivered` message header to `true`.) This
 option can reduce session overhead by minimizing the work the session
 does to prevent duplicates.
 
 If messages have been received from a queue but not acknowledged when a
-`JMSContext` is closed, the JMS provider retains them and redelivers
+`JMSContext` is closed, the Messaging provider retains them and redelivers
 them when a consumer next accesses the queue. The provider also retains
 unacknowledged messages if an application closes a `JMSContext` that has
 been consuming messages from a durable subscription. (See
@@ -179,15 +179,15 @@ producer and call the `send` method.
 Specifying Message Persistence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The JMS API supports two delivery modes specifying whether messages are
-lost if the JMS provider fails. These delivery modes are fields of the
+Jakarta Messaging supports two delivery modes specifying whether messages are
+lost if the Messaging provider fails. These delivery modes are fields of the
 `DeliveryMode` interface.
 
-* The default delivery mode, `PERSISTENT`, instructs the JMS provider to
+* The default delivery mode, `PERSISTENT`, instructs the Messaging provider to
 take extra care to ensure that a message is not lost in transit in case
-of a JMS provider failure. A message sent with this delivery mode is
+of a Messaging provider failure. A message sent with this delivery mode is
 logged to stable storage when it is sent.
-* The `NON_PERSISTENT` delivery mode does not require the JMS provider
+* The `NON_PERSISTENT` delivery mode does not require the Messaging provider
 to store the message or otherwise guarantee that it is not lost if the
 provider fails.
 
@@ -215,7 +215,7 @@ can afford to miss messages.
 Setting Message Priority Levels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can use message priority levels to instruct the JMS provider to
+You can use message priority levels to instruct the Messaging provider to
 deliver urgent messages first. Use the `setPriority` method of the
 `JMSProducer` interface to set the priority level for all messages sent
 by that producer.
@@ -230,7 +230,7 @@ context.createProducer().setPriority(7).send(dest, msg);
 ----
 
 The ten levels of priority range from 0 (lowest) to 9 (highest). If you
-do not specify a priority level, the default level is 4. A JMS provider
+do not specify a priority level, the default level is 4. A Messaging provider
 tries to deliver higher-priority messages before lower-priority ones,
 but does not have to deliver messages in exact order of priority.
 
@@ -270,7 +270,7 @@ Specifying a Delivery Delay
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can specify a length of time that must elapse after a message is
-sent before the JMS provider delivers the message. Use the
+sent before the Messaging provider delivers the message. Use the
 `setDeliveryDelay` method of the `JMSProducer` interface to set a
 delivery delay for all messages sent by that producer.
 
@@ -315,11 +315,11 @@ Creating Temporary Destinations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Normally, you create JMS destinations (queues and topics)
-administratively rather than programmatically. Your JMS provider
+administratively rather than programmatically. Your Messaging provider
 includes a tool to create and remove destinations, and it is common for
 destinations to be long-lasting.
 
-The JMS API also enables you to create destinations (`TemporaryQueue`
+Jakarta Messaging also enables you to create destinations (`TemporaryQueue`
 and `TemporaryTopic` objects) that last only for the duration of the
 connection in which they are created. You create these destinations
 dynamically using the `JMSContext.createTemporaryQueue` and the
@@ -360,7 +360,7 @@ Join Messages from Two MDBs].
 
 [[BNCGH]][[using-jms-local-transactions]]
 
-Using JMS Local Transactions
+Using Jakarta Messaging Local Transactions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A transaction groups a series of operations into an atomic unit of work.
@@ -395,12 +395,12 @@ transaction ends and another transaction begins. Closing a transacted
 session rolls back its transaction in progress, including any pending
 sends and receives.
 
-In an application running in the Jakarta EE web or EJB container, you
-cannot use local transactions. Instead, you use JTA transactions,
-described in link:jms-concepts005.html#BNCGL[Using the JMS API in Jakarta EE
+In an application running in the Jakarta EE web or enterprise bean container, you
+cannot use local transactions. Instead, you use Jakarta Transactions,
+described in link:jms-concepts005.html#BNCGL[Using Jakarta Messaging in Jakarta EE
 Applications].
 
-You can combine several sends and receives in a single JMS local
+You can combine several sends and receives in a single Jakarta Messaging local
 transaction, so long as they are all performed using the same
 `JMSContext`.
 
@@ -426,20 +426,20 @@ receives that depend on that message's having been sent.
 
 The production and the consumption of a message cannot both be part of
 the same transaction. The reason is that the transactions take place
-between the clients and the JMS provider, which intervenes between the
+between the clients and the Messaging provider, which intervenes between the
 production and the consumption of the message. link:#BNCGI[Figure 48-8]
 illustrates this interaction.
 
 [[BNCGI]]
 
-.*Figure 48-8 Using JMS Local Transactions*
+.*Figure 48-8 Using Jakarta Messaging Local Transactions*
 image:img/jakartaeett_dt_033.png[
 "Diagram of local transactions, showing separate transactions for sending
 and consuming a message"]
 
 The sending of one or more messages to one or more destinations by
 Client 1 can form a single transaction, because it forms a single set of
-interactions with the JMS provider using a single `JMSContext`.
+interactions with the Messaging provider using a single `JMSContext`.
 Similarly, the receiving of one or more messages from one or more
 destinations by Client 2 also forms a single transaction using a single
 `JMSContext`. But because the two clients have no direct interaction and
@@ -447,7 +447,7 @@ are using two different `JMSContext` objects, no transactions can take
 place between them.
 
 Another way of putting this is that a transaction is a contract between
-a client and a JMS provider that defines whether a message is sent to a
+a client and a Messaging provider that defines whether a message is sent to a
 destination or whether a message is received from the destination. It is
 not a contract between the sending client and the receiving client.
 
@@ -456,7 +456,7 @@ processing. Instead of tightly coupling the sender and the receiver of a
 message, JMS couples the sender of a message with the destination, and
 it separately couples the destination with the receiver of the message.
 Therefore, while the sends and receives each have a tight coupling with
-the JMS provider, they do not have any coupling with each other.
+the Messaging provider, they do not have any coupling with each other.
 
 When you create a `JMSContext`, you can specify whether it is transacted
 by using the `JMSContext.SESSION_TRANSACTED` argument to the
@@ -478,7 +478,7 @@ session to perform the operations. For example, you can use the same
 topic in the same transaction.
 
 The example in link:jms-examples004.html#BNCGJ[Using Local Transactions]
-shows how to use JMS local transactions.
+shows how to use Jakarta Messaging local transactions.
 
 [[BABFIFAJ]][[sending-messages-asynchronously]]
 
@@ -486,7 +486,7 @@ Sending Messages Asynchronously
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Normally, when you send a persistent message, the `send` method blocks
-until the JMS provider confirms that the message was sent successfully.
+until the Messaging provider confirms that the message was sent successfully.
 The asynchronous send mechanism allows your application to send a
 message and continue work while waiting to learn whether the send
 completed.

--- a/src/main/jbake/content/jms-concepts004.adoc
+++ b/src/main/jbake/content/jms-concepts004.adoc
@@ -5,12 +5,12 @@ next=jms-concepts005.html
 prev=jms-concepts003.html
 ~~~~~~
 Using Advanced Jakarta Messaging Features
-===========================
+=========================================
 
 [[BNCFU]][[using-advanced-jms-features]]
 
 Using Advanced Jakarta Messaging Features
----------------------------
+-----------------------------------------
 
 This section explains how to use features of Jakarta Messaging to achieve the
 level of reliability and performance your application requires. Many
@@ -361,7 +361,7 @@ Join Messages from Two MDBs].
 [[BNCGH]][[using-jms-local-transactions]]
 
 Using Jakarta Messaging Local Transactions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A transaction groups a series of operations into an atomic unit of work.
 If any one of the operations fails, the transaction can be rolled back,

--- a/src/main/jbake/content/jms-concepts005.adoc
+++ b/src/main/jbake/content/jms-concepts005.adoc
@@ -10,7 +10,7 @@ prev=jms-concepts004.html
 [[BNCGL]][[using-the-jms-api-in-jakarta-ee-applications]]
 
 Using Jakarta Messaging in Jakarta EE Applications
---------------------------------------------
+--------------------------------------------------
 
 This section describes how using Jakarta Messaging in enterprise bean
 applications or web applications differs from using it in application
@@ -31,7 +31,7 @@ Asynchronously]
 [[CHDGICJB]][[overview-of-using-the-jms-api]]
 
 Overview of Using Jakarta Messaging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A general rule in the Jakarta EE platform specification applies to all Java
 EE components that use Jakarta Messaging within enterprise bean or web containers:
@@ -255,7 +255,7 @@ resource management and transactions.
 [[BNCGO]][[managing-jms-resources-in-web-and-ejb-components]]
 
 Managing Jakarta Messaging Resources in Web and Jakarta Enterprise Beans Components
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Jakarta Messaging resources are a connection and a session, usually combined in a
 `JMSContext` object. In general, it is important to release Messaging
@@ -494,7 +494,7 @@ link:ejb-intro007.html#GIPKW[The Lifecycle of a Message-Driven Bean].
 [[BNCGS]][[managing-jta-transactions]]
 
 Managing JakartA Transactions
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Jakarta EE application clients and Java SE clients use JMS local
 transactions (described in link:jms-concepts004.html#BNCGH[Using Jakarta Messaging

--- a/src/main/jbake/content/jms-concepts005.adoc
+++ b/src/main/jbake/content/jms-concepts005.adoc
@@ -1,24 +1,24 @@
 type=page
 status=published
-title=Using the JMS API in Jakarta EE Applications
+title=Using Jakarta Messaging in Jakarta EE Applications
 next=jms-concepts006.html
 prev=jms-concepts004.html
 ~~~~~~
-= Using the JMS API in Jakarta EE Applications
+= Using Jakarta Messaging in Jakarta EE Applications
 
 
 [[BNCGL]][[using-the-jms-api-in-jakarta-ee-applications]]
 
-Using the JMS API in Jakarta EE Applications
+Using Jakarta Messaging in Jakarta EE Applications
 --------------------------------------------
 
-This section describes how using the JMS API in enterprise bean
+This section describes how using Jakarta Messaging in enterprise bean
 applications or web applications differs from using it in application
 clients.
 
 The following topics are addressed here:
 
-* link:#CHDGICJB[Overview of Using the JMS API]
+* link:#CHDGICJB[Overview of Using Jakarta Messaging]
 * link:#BABHFBDH[Creating Resources for Jakarta EE Applications]
 * link:#BNCGM[Using Resource Injection in Enterprise Bean or Web
 Components]
@@ -26,16 +26,16 @@ Components]
 Receive Messages]
 * link:#BNCGQ[Using Message-Driven Beans to Receive Messages
 Asynchronously]
-* link:#BNCGS[Managing JTA Transactions]
+* link:#BNCGS[Managing Jakarta Transactions]
 
 [[CHDGICJB]][[overview-of-using-the-jms-api]]
 
-Overview of Using the JMS API
+Overview of Using Jakarta Messaging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A general rule in the Jakarta EE platform specification applies to all Java
-EE components that use the JMS API within EJB or web containers:
-Application components in the web and EJB containers must not attempt to
+EE components that use Jakarta Messaging within enterprise bean or web containers:
+Application components in the web and enterprise bean containers must not attempt to
 create more than one active (not closed) `Session` object per
 connection. Multiple `JMSContext` objects are permitted, however, since
 they combine a single connection and a single session.
@@ -134,7 +134,7 @@ applications
 * `java:app`: Makes the resource available to all components in all
 modules in a single application
 * `java:module`: Makes the resource available to all components within a
-given module (for example, all enterprise beans within an EJB module)
+given module (for example, all enterprise beans within a Jakarta Enterprise Beans module)
 * `java:comp`: Makes the resource available to a single component only
 (except in a web application, where it is equivalent to `java:module`)
 
@@ -174,7 +174,7 @@ application. You may want to use the default connection factory, whose
 JNDI name is `java:comp/DefaultJMSConnectionFactory`.
 
 When you use resource injection in an application client component, you
-normally declare the JMS resource static:
+normally declare the Messaging resource static:
 
 [source,oac_no_warn]
 ----
@@ -233,7 +233,7 @@ Using Jakarta EE Components to Produce and to Synchronously Receive Messages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An application that produces messages or synchronously receives them can
-use a Jakarta EE web or EJB component, such as a managed bean, a servlet,
+use a Jakarta EE web or Jakarta Enterprise Beans component, such as a managed bean, a servlet,
 or a session bean, to perform these operations. The example in
 link:jms-examples008.html#BNCGW[Sending Messages from a Session Bean to
 an MDB] uses a stateless session bean to send messages to a topic. The
@@ -243,39 +243,39 @@ and to consume messages.
 
 Because a synchronous receive with no specified timeout ties up server
 resources, this mechanism usually is not the best application design for
-a web or EJB component. Instead, use a synchronous receive that
+a web or Jakarta Enterprise Beans component. Instead, use a synchronous receive that
 specifies a timeout value, or use a message-driven bean to receive
 messages asynchronously. For details about synchronous receives, see
-link:jms-concepts003.html#BNCEP[JMS Message Consumers].
+link:jms-concepts003.html#BNCEP[Jakarta Messaging Message Consumers].
 
-Using the JMS API in a Jakarta EE component is in many ways similar to
+Using Jakarta Messaging in a Jakarta EE component is in many ways similar to
 using it in an application client. The main differences are the areas of
 resource management and transactions.
 
 [[BNCGO]][[managing-jms-resources-in-web-and-ejb-components]]
 
-Managing JMS Resources in Web and EJB Components
+Managing Jakarta Messaging Resources in Web and Jakarta Enterprise Beans Components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The JMS resources are a connection and a session, usually combined in a
-`JMSContext` object. In general, it is important to release JMS
+The Jakarta Messaging resources are a connection and a session, usually combined in a
+`JMSContext` object. In general, it is important to release Messaging
 resources when they are no longer being used. Here are some useful
 practices to follow.
 
-* If you wish to maintain a JMS resource only for the life span of a
+* If you wish to maintain a Messaging resource only for the life span of a
 business method, use a `try`-with-resources statement to create the
 `JMSContext` so that it will be closed automatically at the end of the
 `try` block.
-* To maintain a JMS resource for the duration of a transaction or
+* To maintain a Messaging resource for the duration of a transaction or
 request, inject the `JMSContext` as described in
 link:#BABCJBEE[Injecting a JMSContext Object]. This will also cause the
 resource to be released when it is no longer needed.
-* If you would like to maintain a JMS resource for the life span of an
+* If you would like to maintain a Messaging resource for the life span of an
 enterprise bean instance, you can use a `@PostConstruct` callback method
 to create the resource and a `@PreDestroy` callback method to close the
 resource. However, there is normally no need to do this, since
 application servers usually maintain a pool of connections. If you use a
-stateful session bean and you wish to maintain the JMS resource in a
+stateful session bean and you wish to maintain the Messaging resource in a
 cached state, you must close the resource in a `@PrePassivate` callback
 method and set its value to `null`, and you must create it again in a
 `@PostActivate` callback method.
@@ -285,10 +285,10 @@ method and set its value to `null`, and you must create it again in a
 Managing Transactions in Session Beans
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Instead of using local transactions, you use JTA transactions. You can
+Instead of using local transactions, you use Jakarta transactions. You can
 use either container-managed transactions or bean-managed transactions.
 Normally, you use container-managed transactions for bean methods that
-perform sends or receives, allowing the EJB container to handle
+perform sends or receives, allowing the enterprise bean container to handle
 transaction demarcation. Because container-managed transactions are the
 default, you do not have to specify them.
 
@@ -306,11 +306,11 @@ Using Message-Driven Beans to Receive Messages Asynchronously
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The sections link:ejb-intro003.html#GIPKO[What Is a Message-Driven Bean?]
-and link:jms-concepts001.html#BNCDW[How Does the JMS API Work with the
+and link:jms-concepts001.html#BNCDW[How Does Jakarta Messaging Work with the
 Jakarta EE Platform?] describe how the Jakarta EE platform supports a special
 kind of enterprise bean, the message-driven bean, which allows Jakarta EE
-applications to process JMS messages asynchronously. Other Jakarta EE web
-and EJB components allow you to send messages and to receive them
+applications to process Jakarta Messaging messages asynchronously. Other Jakarta EE web
+and Jakarta Enterprise Beans components allow you to send messages and to receive them
 synchronously but not asynchronously.
 
 A message-driven bean is a message listener to which messages can be
@@ -329,7 +329,7 @@ not use a deployment descriptor.
 
 It is recommended, but not required, that a message-driven bean class
 implement the message listener interface for the message type it
-supports. A bean that supports the JMS API implements the
+supports. A bean that supports Jakarta Messaging implements the
 `javax.jms.MessageListener` interface, which means that it must provide
 an `onMessage` method with the following signature:
 
@@ -350,7 +350,7 @@ listener in the following ways.
 * In an application client, you must create a `JMSContext`, then create
 a `JMSConsumer`, then call `setMessageListener` to activate the
 listener. For a message-driven bean, you need only define the class and
-annotate it, and the EJB container creates it for you.
+annotate it, and the enterprise bean container creates it for you.
 * The bean class uses the `@MessageDriven` annotation, which typically
 contains an `activationConfig` element containing
 `@ActivationConfigProperty` annotations that specify properties used by
@@ -401,10 +401,10 @@ Subscriptions] for more information
 subscription
 
 |`messageSelector` |A string that filters messages; see
-link:jms-concepts003.html#BNCER[JMS Message Selectors] for information
+link:jms-concepts003.html#BNCER[Jakarta Messaging Message Selectors] for information
 
 |`connectionFactoryLookup` |The lookup name of the connection factory to
-be used to connect to the JMS provider from which the bean will receive
+be used to connect to the Messaging provider from which the bean will receive
 messages
 |=======================================================================
 
@@ -453,8 +453,8 @@ public class SimpleMessageBean implements MessageListener {
 }
 ----
 
-If JMS is integrated with the application server using a resource
-adapter, the JMS resource adapter handles these tasks for the EJB
+If Jakarta Messaging is integrated with the application server using a resource
+adapter, the Messaging resource adapter handles these tasks for the enterprise bean
 container.
 
 The bean class commonly injects a `MessageDrivenContext` resource, which
@@ -493,37 +493,37 @@ link:ejb-intro007.html#GIPKW[The Lifecycle of a Message-Driven Bean].
 
 [[BNCGS]][[managing-jta-transactions]]
 
-Managing JTA Transactions
+Managing JakartA Transactions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Jakarta EE application clients and Java SE clients use JMS local
-transactions (described in link:jms-concepts004.html#BNCGH[Using JMS
+transactions (described in link:jms-concepts004.html#BNCGH[Using Jakarta Messaging
 Local Transactions]), which allow the grouping of sends and receives
-within a specific JMS session. Jakarta EE applications that run in the web
-or EJB container commonly use JTA transactions to ensure the integrity
-of accesses to external resources. The key difference between a JTA
-transaction and a JMS local transaction is that a JTA transaction is
-controlled by the application server's transaction managers. JTA
+within a specific Messaging session. Jakarta EE applications that run in the web
+or enterprise bean container commonly use Jakarta Transactions to ensure the integrity
+of accesses to external resources. The key difference between a Jakarta
+transaction and a Jakarta Messaging local transaction is that a Jakarta transaction is
+controlled by the application server's transaction managers. Jakarta
 transactions may be distributed, which means that they can encompass
-multiple resources in the same transaction, such as a JMS provider and a
+multiple resources in the same transaction, such as a Messaging provider and a
 database.
 
 For example, distributed transactions allow multiple applications to
 perform atomic updates on the same database, and they allow a single
 application to perform atomic updates on multiple databases.
 
-In a Jakarta EE application that uses the JMS API, you can use transactions
+In a Jakarta EE application that uses Jakarta Messaging, you can use transactions
 to combine message sends or receives with database updates and other
 resource manager operations. You can access resources from multiple
 application components within a single transaction. For example, a
 servlet can start a transaction, access multiple databases, invoke an
-enterprise bean that sends a JMS message, invoke another enterprise bean
+enterprise bean that sends a Jakarta Messaging message, invoke another enterprise bean
 that modifies an EIS system using the Connector Architecture, and
 finally commit the transaction. Your application cannot, however, both
-send a JMS message and receive a reply to it within the same
+send a Jakarta Messaging message and receive a reply to it within the same
 transaction.
 
-JTA transactions within the EJB and web containers can be either of two
+Jakarta Transactions within the enterprise bean and web containers can be either of two
 kinds.
 
 * Container-managed transactions: The container controls the integrity
@@ -561,7 +561,7 @@ possible outcome of the transaction is a rollback.
 transaction has been marked for rollback.
 
 If you use bean-managed transactions, the delivery of a message to the
-`onMessage` method takes place outside the JTA transaction context. The
+`onMessage` method takes place outside the Jakarta transaction context. The
 transaction begins when you call the `UserTransaction.begin` method
 within the `onMessage` method, and it ends when you call
 `UserTransaction.commit` or `UserTransaction.rollback`. Any call to the
@@ -575,10 +575,10 @@ container-managed transactions, the message is received by the MDB and
 processed by the `onMessage` method within the same transaction. It is
 not possible to achieve this behavior with bean-managed transactions.
 
-When you create a `JMSContext` in a JTA transaction (in the web or EJB
+When you create a `JMSContext` in a Jakarta transaction (in the web or enterprise bean
 container), the container ignores any arguments you specify, because it
 manages all transactional properties. When you create a `JMSContext` in
-the web or EJB container and there is no JTA transaction, the value (if
+the web or enterprise bean container and there is no Jakarta transaction, the value (if
 any) passed to the `createContext` method should be
 `JMSContext.AUTO_ACKNOWLEDGE` or `JMSContext.DUPS_OK_ACKNOWLEDGE`.
 
@@ -598,5 +598,5 @@ activation configuration property `acknowledgeMode` to
 message received by the message-driven bean to be acknowledged.
 
 If the `onMessage` method throws a `RuntimeException`, the container
-does not acknowledge processing the message. In that case, the JMS
+does not acknowledge processing the message. In that case, the Messaging
 provider will redeliver the unacknowledged message in the future.

--- a/src/main/jbake/content/jms-concepts005.adoc
+++ b/src/main/jbake/content/jms-concepts005.adoc
@@ -255,7 +255,7 @@ resource management and transactions.
 [[BNCGO]][[managing-jms-resources-in-web-and-ejb-components]]
 
 Managing Jakarta Messaging Resources in Web and Jakarta Enterprise Beans Components
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Jakarta Messaging resources are a connection and a session, usually combined in a
 `JMSContext` object. In general, it is important to release Messaging

--- a/src/main/jbake/content/jms-concepts006.adoc
+++ b/src/main/jbake/content/jms-concepts006.adoc
@@ -1,24 +1,19 @@
 type=page
 status=published
-title=Further Information about JMS
+title=Further Information about Jakarta Messaging
 next=jms-examples.html
 prev=jms-concepts005.html
 ~~~~~~
-Further Information about JMS
+Further Information about Jakarta Messaging
 =============================
 
 [[BNCGU]][[further-information-about-jms]]
 
-Further Information about JMS
+Further Information about Jakarta Messaging
 -----------------------------
 
-For more information about JMS, see
+For more information about Jakarta Messaging, see
 
-* Java Message Service website:
+* Jakarta Messaging website:
 +
-`http://www.oracle.com/technetwork/java/index-jsp-142945.html`
-* Java Message Service specification, version 2.0, available from:
-+
-`http://jcp.org/en/jsr/detail?id=343`
-
-
+`https://projects.eclipse.org/projects/ee4j.jms`

--- a/src/main/jbake/content/jms-concepts006.adoc
+++ b/src/main/jbake/content/jms-concepts006.adoc
@@ -5,15 +5,19 @@ next=jms-examples.html
 prev=jms-concepts005.html
 ~~~~~~
 Further Information about Jakarta Messaging
-=============================
+===========================================
 
 [[BNCGU]][[further-information-about-jms]]
 
 Further Information about Jakarta Messaging
------------------------------
+-------------------------------------------
 
 For more information about Jakarta Messaging, see
 
 * Jakarta Messaging website:
 +
 `https://projects.eclipse.org/projects/ee4j.jms`
+
+* Jakarta Messaging specification, version 2.0, available from:
+
+`https://jakarta.ee/specifications/messaging/2.0/`

--- a/src/main/jbake/content/jms-examples.adoc
+++ b/src/main/jbake/content/jms-examples.adoc
@@ -4,13 +4,13 @@ title=Jakarta Messaging Examples
 next=jms-examples001.html
 prev=jms-concepts006.html
 ~~~~~~
-Java Messaging Examples
-=============================
+Jakarta Messaging Examples
+==========================
 
 [[BNCGV]][[java-message-service-examples]]
 
-49 Java Messaging Examples
---------------------------------
+49 Jakarta Messaging Examples
+--------------------------
 
 
 This chapter provides examples that show how to use Jakarta Messaging in
@@ -18,7 +18,7 @@ various kinds of Jakarta EE applications.
 
 The following topics are addressed here:
 
-* link:jms-examples001.html#A1251921[Building and Running Java Message
+* link:jms-examples001.html#A1251921[Building and Running Jakarta Messaging
 Service Examples]
 * link:jms-examples002.html#BABEFBHJ[Overview of the Jakarta Messaging Examples]
 * link:jms-examples003.html#BNCFA[Writing Simple Jakarta Messaging Applications]

--- a/src/main/jbake/content/jms-examples.adoc
+++ b/src/main/jbake/content/jms-examples.adoc
@@ -1,30 +1,30 @@
 type=page
 status=published
-title=Java Message Service Examples
+title=Jakarta Messaging Examples
 next=jms-examples001.html
 prev=jms-concepts006.html
 ~~~~~~
-Java Message Service Examples
+Java Messaging Examples
 =============================
 
 [[BNCGV]][[java-message-service-examples]]
 
-49 Java Message Service Examples
+49 Java Messaging Examples
 --------------------------------
 
 
-This chapter provides examples that show how to use the JMS API in
+This chapter provides examples that show how to use Jakarta Messaging in
 various kinds of Jakarta EE applications.
 
 The following topics are addressed here:
 
 * link:jms-examples001.html#A1251921[Building and Running Java Message
 Service Examples]
-* link:jms-examples002.html#BABEFBHJ[Overview of the JMS Examples]
-* link:jms-examples003.html#BNCFA[Writing Simple JMS Applications]
-* link:jms-examples004.html#GIWFH[Writing More Advanced JMS Applications]
+* link:jms-examples002.html#BABEFBHJ[Overview of the Jakarta Messaging Examples]
+* link:jms-examples003.html#BNCFA[Writing Simple Jakarta Messaging Applications]
+* link:jms-examples004.html#GIWFH[Writing More Advanced Jakarta Messaging Applications]
 * link:jms-examples005.html#BABGEFHC[Writing High Performance and
-Scalable JMS Applications]
+Scalable Jakarta Messaging Applications]
 * link:jms-examples006.html#BABBABFC[Sending and Receiving Messages Using
 a Simple Web Application]
 * link:jms-examples007.html#BNBPK[Receiving Messages Asynchronously Using
@@ -33,5 +33,5 @@ a Message-Driven Bean]
 an MDB]
 * link:jms-examples009.html#BNCHF[Using an Entity to Join Messages from
 Two MDBs]
-* link:jms-examples010.html#BABDFDJC[Using NetBeans IDE to Create JMS
+* link:jms-examples010.html#BABDFDJC[Using NetBeans IDE to Create Jakarta Messaging
 Resources]

--- a/src/main/jbake/content/jms-examples.adoc
+++ b/src/main/jbake/content/jms-examples.adoc
@@ -10,7 +10,7 @@ Jakarta Messaging Examples
 [[BNCGV]][[java-message-service-examples]]
 
 49 Jakarta Messaging Examples
---------------------------
+-----------------------------
 
 
 This chapter provides examples that show how to use Jakarta Messaging in

--- a/src/main/jbake/content/jms-examples001.adoc
+++ b/src/main/jbake/content/jms-examples001.adoc
@@ -10,7 +10,7 @@ prev=jms-examples.html
 [[A1251921]][[building-and-running-java-message-service-examples]]
 
 Building and Running Jakarta Messaging Examples
---------------------------------------------------
+-----------------------------------------------
 
 The examples are in the `_tut-install_/examples/jms/` directory.
 

--- a/src/main/jbake/content/jms-examples001.adoc
+++ b/src/main/jbake/content/jms-examples001.adoc
@@ -1,15 +1,15 @@
 type=page
 status=published
-title=Building and Running Java Message Service Examples
+title=Building and Running Jakarta Messaging Examples
 next=jms-examples002.html
 prev=jms-examples.html
 ~~~~~~
-= Building and Running Java Message Service Examples
+= Building and Running Jakarta Messaging Examples
 
 
 [[A1251921]][[building-and-running-java-message-service-examples]]
 
-Building and Running Java Message Service Examples
+Building and Running Jakarta Messaging Examples
 --------------------------------------------------
 
 The examples are in the `_tut-install_/examples/jms/` directory.

--- a/src/main/jbake/content/jms-examples002.adoc
+++ b/src/main/jbake/content/jms-examples002.adoc
@@ -10,7 +10,7 @@ prev=jms-examples001.html
 [[BABEFBHJ]][[overview-of-the-jms-examples]]
 
 Overview of the Jakarta Messaging Examples
-----------------------------
+------------------------------------------
 
 The following tables list the examples used in this chapter, describe
 what they do, and link to the section that describes them fully. The
@@ -63,7 +63,7 @@ link:jms-examples005.html#BABEJBHA[Using Shared Durable Subscriptions]
 
 [[sthref202]][[sthref203]]
 
-*Table 49-2 Jakarta Messaging Examples That Show the Use of Jakarta EE Web and EJB
+*Table 49-2 Jakarta Messaging Examples That Show the Use of Jakarta EE Web and Enterprise Bean
 Components*
 
 [width="80%",cols="20%,60%s"]

--- a/src/main/jbake/content/jms-examples002.adoc
+++ b/src/main/jbake/content/jms-examples002.adoc
@@ -1,15 +1,15 @@
 type=page
 status=published
-title=Overview of the JMS Examples
+title=Overview of the Jakarta Messaging Examples
 next=jms-examples003.html
 prev=jms-examples001.html
 ~~~~~~
-= Overview of the JMS Examples
+= Overview of the Jakarta Messaging Examples
 
 
 [[BABEFBHJ]][[overview-of-the-jms-examples]]
 
-Overview of the JMS Examples
+Overview of the Jakarta Messaging Examples
 ----------------------------
 
 The following tables list the examples used in this chapter, describe
@@ -19,7 +19,7 @@ example directory for each example is relative to the
 
 [[sthref200]][sthref201]]
 
-*Table 49-1 JMS Examples That Show the Use of Jakarta EE Application Clients*
+*Table 49-1 Jakarta Messaging Examples That Show the Use of Jakarta EE Application Clients*
 
 [width="80%",cols="20%,60%s"]
 |=======================================================================
@@ -63,7 +63,7 @@ link:jms-examples005.html#BABEJBHA[Using Shared Durable Subscriptions]
 
 [[sthref202]][[sthref203]]
 
-*Table 49-2 JMS Examples That Show the Use of Jakarta EE Web and EJB
+*Table 49-2 Jakarta Messaging Examples That Show the Use of Jakarta EE Web and EJB
 Components*
 
 [width="80%",cols="20%,60%s"]

--- a/src/main/jbake/content/jms-examples003.adoc
+++ b/src/main/jbake/content/jms-examples003.adoc
@@ -1,25 +1,25 @@
 type=page
 status=published
-title=Writing Simple JMS Applications
+title=Writing Simple Jakarta Messaging Applications
 next=jms-examples004.html
 prev=jms-examples002.html
 ~~~~~~
-= Writing Simple JMS Applications
+= Writing Simple Jakarta Messaging Applications
 
 
 [[BNCFA]][[writing-simple-jms-applications]]
 
-Writing Simple JMS Applications
+Writing Simple Jakarta Messaging Applications
 -------------------------------
 
-This section shows how to create, package, and run simple JMS clients
+This section shows how to create, package, and run simple Messaging clients
 that are packaged as application clients.
 
 The following topics are addressed here:
 
-* link:#CHDCEFGA[Overview of Writing Simple JMS Application]
-* link:#BNCFD[Starting the JMS Provider]
-* link:#GKTJS[Creating JMS Administered Objects]
+* link:#CHDCEFGA[Overview of Writing Simple Jakarta Messaging Application]
+* link:#BNCFD[Starting the Jakarta Messaging Provider]
+* link:#GKTJS[Creating Jakarta Messaging Administered Objects]
 * link:#BABEEABE[Building All the Simple Examples]
 * link:#BABIHCAE[Sending Messages]
 * link:#BNCFB[Receiving Messages Synchronously]
@@ -31,10 +31,10 @@ Delivery]
 
 [[CHDCEFGA]][[overview-of-writing-simple-jms-application]]
 
-Overview of Writing Simple JMS Application
+Overview of Writing Simple Jakarta Messaging Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The clients demonstrate the basic tasks a JMS application must perform:
+The clients demonstrate the basic tasks a Jakarta Messaging application must perform:
 
 * Creating a `JMSContext`
 * Creating message producers and consumers
@@ -43,10 +43,10 @@ The clients demonstrate the basic tasks a JMS application must perform:
 Each example uses two clients: one that sends messages and one that
 receives them. You can run the clients in two terminal windows.
 
-When you write a JMS client to run in an enterprise bean application,
+When you write a Messaging client to run in an enterprise bean application,
 you use many of the same methods in much the same sequence as for an
 application client. However, there are some significant differences.
-link:jms-concepts005.html#BNCGL[Using the JMS API in Jakarta EE
+link:jms-concepts005.html#BNCGL[Using Jakarta Messaging in Jakarta EE
 Applications] describes these differences, and this chapter provides
 examples that illustrate them.
 
@@ -65,31 +65,31 @@ create administered objects.
 
 [[BNCFD]][[starting-the-jms-provider]]
 
-Starting the JMS Provider
+Starting the Jakarta Messaging Provider
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you use GlassFish Server, your JMS provider is GlassFish Server.
+When you use GlassFish Server, your Messaging provider is GlassFish Server.
 Start the server as described in
 link:usingexamples002.html#BNADI[Starting and Stopping GlassFish Server].
 
 [[GKTJS]][[creating-jms-administered-objects]]
 
-Creating JMS Administered Objects
+Creating Jakarta Messaging Administered Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This example uses the following JMS administered objects:
+This example uses the following Jakarta Messaging administered objects:
 
 * A connection factory
 * Two destination resources: a topic and a queue
 
 Before you run the applications, you can use the `asadmin add-resources`
-command to create needed JMS resources, specifying as the argument a
+command to create needed Messaging resources, specifying as the argument a
 file named `glassfish-resources.xml`. This file can be created in any
 project using NetBeans IDE, although you can also create it by hand. A
 file for the needed resources is present in the
 `jms/simple/producer/src/main/setup/` directory.
 
-The JMS examples use a connection factory with the logical JNDI lookup
+The Jakarta Messaging examples use a connection factory with the logical JNDI lookup
 name `java:comp/DefaultJMSConnectionFactory`, which is preconfigured in
 GlassFish Server.
 
@@ -350,8 +350,8 @@ You will use the client to send three messages to a queue.
 
 1.  Make sure that GlassFish Server has been started (see
 link:usingexamples002.html#BNADI[Starting and Stopping GlassFish Server])
-and that you have created resources and built the simple JMS examples
-(see link:#GKTJS[Creating JMS Administered Objects] and
+and that you have created resources and built the simple Jakarta Messaging examples
+(see link:#GKTJS[Creating Jakarta Messaging Administered Objects] and
 link:#BABEEABE[Building All the Simple Examples]).
 2.  In a terminal window, go to the `producer` directory:
 +
@@ -1027,7 +1027,7 @@ subscription on the topic. Therefore, each of the clients receives all
 Acknowledging Messages
 ~~~~~~~~~~~~~~~~~~~~~~
 
-JMS provides two alternative ways for a consuming client to ensure that
+Jakarta Messaging provides two alternative ways for a consuming client to ensure that
 a message is not acknowledged until the application has finished
 processing the message:
 

--- a/src/main/jbake/content/jms-examples003.adoc
+++ b/src/main/jbake/content/jms-examples003.adoc
@@ -10,7 +10,7 @@ prev=jms-examples002.html
 [[BNCFA]][[writing-simple-jms-applications]]
 
 Writing Simple Jakarta Messaging Applications
--------------------------------
+---------------------------------------------
 
 This section shows how to create, package, and run simple Messaging clients
 that are packaged as application clients.
@@ -32,7 +32,7 @@ Delivery]
 [[CHDCEFGA]][[overview-of-writing-simple-jms-application]]
 
 Overview of Writing Simple Jakarta Messaging Application
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The clients demonstrate the basic tasks a Jakarta Messaging application must perform:
 
@@ -66,7 +66,7 @@ create administered objects.
 [[BNCFD]][[starting-the-jms-provider]]
 
 Starting the Jakarta Messaging Provider
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When you use GlassFish Server, your Messaging provider is GlassFish Server.
 Start the server as described in
@@ -75,7 +75,7 @@ link:usingexamples002.html#BNADI[Starting and Stopping GlassFish Server].
 [[GKTJS]][[creating-jms-administered-objects]]
 
 Creating Jakarta Messaging Administered Objects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This example uses the following Jakarta Messaging administered objects:
 

--- a/src/main/jbake/content/jms-examples004.adoc
+++ b/src/main/jbake/content/jms-examples004.adoc
@@ -1,19 +1,19 @@
 type=page
 status=published
-title=Writing More Advanced JMS Applications
+title=Writing More Advanced Jakarta Messaging Applications
 next=jms-examples005.html
 prev=jms-examples003.html
 ~~~~~~
-Writing More Advanced JMS Applications
+Writing More Advanced Jakarta Messaging Applications
 ======================================
 
 [[GIWFH]][[writing-more-advanced-jms-applications]]
 
-Writing More Advanced JMS Applications
+Writing More Advanced Jakarta Messaging Applications
 --------------------------------------
 
-The following examples show how to use some of the more advanced
-features of the JMS API: durable subscriptions and transactions.
+The following examples show how to use some of the more advanced Jakarta Messaging
+features: durable subscriptions and transactions.
 
 The following topics are addressed here:
 
@@ -224,7 +224,7 @@ Using Local Transactions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `transactedexample` example demonstrates the use of local
-transactions in a JMS client application. It also demonstrates the use
+transactions in a Messaging client application. It also demonstrates the use
 of the request/reply messaging pattern described in
 link:jms-concepts004.html#BNCGB[Creating Temporary Destinations],
 although it uses permanent rather than temporary destinations. The
@@ -262,7 +262,7 @@ orderConfirmReceiver = context.createConsumer(retailerConfirmQueue);
 2.  The vendor
 (`vendor/src/main/java/javaeetutorial/retailer/Vendor.java`) receives
 the retailer's order message and sends an order message to the supplier
-order topic in one transaction. This JMS transaction uses a single
+order topic in one transaction. This Jakarta Messaging transaction uses a single
 session, so you can combine a receive from a queue with a send to a
 topic. Here is the code that uses the same session to create a consumer
 for a queue:
@@ -295,7 +295,7 @@ receives the order from the order topic, checks its inventory, and then
 sends the items ordered to the queue named in the order message's
 `JMSReplyTo` field. If it does not have enough of the item in stock, the
 supplier sends what it has. The synchronous receive from the topic and
-the send to the queue take place in one JMS transaction:
+the send to the queue take place in one Jakarta Messaging transaction:
 +
 [source,oac_no_warn]
 ----
@@ -317,7 +317,7 @@ context.commit();
 4.  The vendor receives the suppliers' replies from its confirmation
 queue and updates the state of the order. Messages are processed by an
 asynchronous message listener, `VendorMessageListener`; this step shows
-the use of JMS transactions with a message listener:
+the use of Jakarta Messaging transactions with a message listener:
 +
 [source,oac_no_warn]
 ----
@@ -353,7 +353,7 @@ link:#BNCGK[Figure 49-1] illustrates these steps.
 
 [[BNCGK]]
 
-.*Figure 49-1 Transactions: JMS Client Example*
+.*Figure 49-1 Transactions: Messaging Client Example*
 
 image:img/jakartaeett_dt_034.png[
 "Diagram of steps in transaction example"]

--- a/src/main/jbake/content/jms-examples004.adoc
+++ b/src/main/jbake/content/jms-examples004.adoc
@@ -5,12 +5,12 @@ next=jms-examples005.html
 prev=jms-examples003.html
 ~~~~~~
 Writing More Advanced Jakarta Messaging Applications
-======================================
+====================================================
 
 [[GIWFH]][[writing-more-advanced-jms-applications]]
 
 Writing More Advanced Jakarta Messaging Applications
---------------------------------------
+----------------------------------------------------
 
 The following examples show how to use some of the more advanced Jakarta Messaging
 features: durable subscriptions and transactions.

--- a/src/main/jbake/content/jms-examples005.adoc
+++ b/src/main/jbake/content/jms-examples005.adoc
@@ -1,18 +1,18 @@
 type=page
 status=published
-title=Writing High Performance and Scalable JMS Applications
+title=Writing High Performance and Scalable Jakarta Messaging Applications
 next=jms-examples006.html
 prev=jms-examples004.html
 ~~~~~~
-Writing High Performance and Scalable JMS Applications
+Writing High Performance and Scalable Jakarta Messaging Applications
 ======================================================
 
 [[BABGEFHC]][[writing-high-performance-and-scalable-jms-applications]]
 
-Writing High Performance and Scalable JMS Applications
+Writing High Performance and Scalable Jakarta Messaging Applications
 ------------------------------------------------------
 
-This section describes how to use the JMS API to write applications that
+This section describes how to use Jakarta Messaging to write applications that
 can handle high volumes of messages robustly. These examples use both
 nondurable and durable shared consumers.
 

--- a/src/main/jbake/content/jms-examples005.adoc
+++ b/src/main/jbake/content/jms-examples005.adoc
@@ -5,12 +5,12 @@ next=jms-examples006.html
 prev=jms-examples004.html
 ~~~~~~
 Writing High Performance and Scalable Jakarta Messaging Applications
-======================================================
+====================================================================
 
 [[BABGEFHC]][[writing-high-performance-and-scalable-jms-applications]]
 
 Writing High Performance and Scalable Jakarta Messaging Applications
-------------------------------------------------------
+--------------------------------------------------------------------
 
 This section describes how to use Jakarta Messaging to write applications that
 can handle high volumes of messages robustly. These examples use both

--- a/src/main/jbake/content/jms-examples006.adoc
+++ b/src/main/jbake/content/jms-examples006.adoc
@@ -12,12 +12,12 @@ Sending and Receiving Messages Using a Simple Web Application
 Sending and Receiving Messages Using a Simple Web Application
 -------------------------------------------------------------
 
-Web applications can use the JMS API to send and receive messages, as
+Web applications can use Jakarta Messaging to send and receive messages, as
 noted in link:jms-concepts005.html#BNCGN[Using Jakarta EE Components to
 Produce and to Synchronously Receive Messages]. This section describes
-the components of a very simple web application that uses the JMS API.
+the components of a very simple web application that uses Jakarta Messaging.
 
-This section assumes that you are familiar with the basics of JavaServer
+This section assumes that you are familiar with the basics of Jakarta Server
 Faces technology, described in link:partwebtier.html#BNADP[Part IX, "The
 Web Tier."]
 

--- a/src/main/jbake/content/jms-examples007.adoc
+++ b/src/main/jbake/content/jms-examples007.adoc
@@ -18,7 +18,7 @@ messages asynchronously, you need to define a class that implements the
 `MessageListener` interface, create a `JMSConsumer`, and call the method
 `setMessageListener`.
 
-If you're writing an application to run in the Jakarta EE web or EJB
+If you're writing an application to run in the Jakarta EE web or enterprise bean
 container and want it to receive messages asynchronously, you also need
 to need to define a class that implements the `MessageListener`
 interface. However, instead of creating a `JMSConsumer` and calling the
@@ -27,7 +27,7 @@ class to be a message-driven bean. The application server will then take
 care of the rest.
 
 Message-driven beans can implement any messaging type. Most commonly,
-however, they implement the Java Message Service (JMS) technology.
+however, they implement the Jakarta Messaging technology.
 
 This section describes a simple message-driven bean example. Before
 proceeding, you should read the basic conceptual information in the
@@ -49,7 +49,7 @@ processes the messages that are sent to the queue
 
 link:#BNBPM[Figure 49-3] illustrates the structure of this application.
 The application client sends messages to the queue, which was created
-administratively using the Administration Console. The JMS provider (in
+administratively using the Administration Console. The Messaging provider (in
 this case, GlassFish Server) delivers the messages to the instances of
 the message-driven bean, which then processes the messages.
 
@@ -139,8 +139,8 @@ to an MDB] for examples of the `subscriptionDurability`, `clientId`,
 The onMessage Method
 ^^^^^^^^^^^^^^^^^^^^
 
-When the queue receives a message, the EJB container invokes the message
-listener method or methods. For a bean that uses JMS, this is the
+When the queue receives a message, the enterprise bean container invokes the message
+listener method or methods. For a bean that uses Jakarta Messaging, this is the
 `onMessage` method of the `MessageListener` interface.
 
 In the `SimpleMessageBean` class, the `onMessage` method casts the
@@ -191,14 +191,14 @@ Creating Resources for the simplemessage Example
 This example uses the queue named `jms/MyQueue` and the preconfigured
 default connection factory `java:comp/DefaultJMSConnectionFactory`.
 
-If you have run the simple JMS examples in
-link:jms-examples003.html#BNCFA[Writing Simple JMS Applications] and have
+If you have run the simple Jakarta Messaging examples in
+link:jms-examples003.html#BNCFA[Writing Simple Jakarta Messaging Applications] and have
 not deleted the resources, you already have the queue. Otherwise, follow
 the instructions in link:jms-examples003.html#BABHEFCB[To Create
 Resources for the Simple Examples] to create it.
 
-For more information on creating JMS resources, see
-link:jms-examples003.html#GKTJS[Creating JMS Administered Objects].
+For more information on creating Messaging resources, see
+link:jms-examples003.html#GKTJS[Creating Jakarta Messaging Administered Objects].
 
 [[CHDFBDDA]][[to-run-the-simplemessage-example-using-netbeans-ide]]
 

--- a/src/main/jbake/content/jms-examples008.adoc
+++ b/src/main/jbake/content/jms-examples008.adoc
@@ -13,7 +13,7 @@ Sending Messages from a Session Bean to an MDB
 ----------------------------------------------
 
 This section explains how to write, compile, package, deploy, and run an
-application that uses the JMS API in conjunction with a session bean.
+application that uses Jakarta Messaging in conjunction with a session bean.
 The application contains the following components:
 
 * An application client that invokes a session bean
@@ -73,7 +73,7 @@ Coding the Application Client: MyAppClient.java
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The application client, `MyAppClient.java`, found under
-`clientsessionmdb-app-client`, performs no JMS API operations and so is
+`clientsessionmdb-app-client`, performs no Messaging operations and so is
 simpler than the client in link:jms-examples007.html#BNBPK[Receiving
 Messages Asynchronously Using a Message-Driven Bean]. The client uses
 dependency injection to obtain the Publisher enterprise bean's business
@@ -176,7 +176,7 @@ The topic is the one defined in the `PublisherBean`. The message
 selector in this case represents both the sports and opinion desks, just
 to demonstrate the syntax of message selectors.
 
-The JMS resource adapter uses these properties to create a connection
+The Jakarta Messaging resource adapter uses these properties to create a connection
 factory for the message-driven bean that allows the bean to use a
 durable subscription.
 
@@ -223,9 +223,9 @@ This command creates the following:
 
 ** An application client JAR file that contains the client class file and
 the session bean's remote interface, along with a manifest file that
-specifies the main class and places the EJB JAR file in its classpath
+specifies the main class and places the Jakarta Enterprise Beans JAR file in its classpath
 
-** An EJB JAR file that contains both the session bean and the
+** An enterprise bean JAR file that contains both the session bean and the
 message-driven bean
 
 ** An application EAR file that contains the two JAR files
@@ -277,8 +277,8 @@ This command creates the following:
 
 ** An application client JAR file that contains the client class file and
 the session bean's remote interface, along with a manifest file that
-specifies the main class and places the EJB JAR file in its classpath
-** An EJB JAR file that contains both the session bean and the
+specifies the main class and places the enterprise bean JAR file in its classpath
+** An enterprise bean JAR file that contains both the session bean and the
 message-driven bean
 ** An application EAR file that contains the two JAR files
 +

--- a/src/main/jbake/content/jms-examples009.adoc
+++ b/src/main/jbake/content/jms-examples009.adoc
@@ -13,7 +13,7 @@ Using an Entity to Join Messages from Two MDBs
 ----------------------------------------------
 
 This section explains how to write, compile, package, deploy, and run an
-application that uses the JMS API with an entity. The application uses
+application that uses the Jakarta Messaging with an entity. The application uses
 the following components:
 
 * An application client that both sends and receives messages
@@ -39,12 +39,12 @@ Overview of the clientmdbentity Example Application
 This application simulates, in a simplified way, the work flow of a
 company's human resources (HR) department when it processes a new hire.
 This application also demonstrates how to use the Jakarta EE platform to
-accomplish a task that many JMS applications need to perform.
+accomplish a task that many Messaging applications need to perform.
 
 A messaging client must often wait for several messages from various
 sources. It then uses the information in all these messages to assemble
 a message that it then sends to another destination. The common term for
-this design pattern (which is not specific to JMS) is joining messages.
+this design pattern (which is not specific to Jakarta Messaging) is joining messages.
 Such a task must be transactional, with all the receives and the send as
 a single transaction. If not all the messages are received successfully,
 the transaction can be rolled back. For an application client example
@@ -53,8 +53,8 @@ Local Transactions].
 
 A message-driven bean can process only one message at a time in a
 transaction. To provide the ability to join messages, an application can
-have the message-driven bean store the interim information in a Java
-Persistence API entity. The entity can then determine whether all the
+have the message-driven bean store the interim information in a Jakarta
+Persistence entity. The entity can then determine whether all the
 information has been received; when it has, the entity can report this
 back to one of the message-driven beans, which then creates and sends
 the message to the other destination. After it has completed its task,
@@ -129,7 +129,7 @@ The application client, `HumanResourceClient.java`, found under
 `clientmdbentity-app-client`, performs the following steps:
 
 1.  Defines a topic for the application, using the `java:app` namespace
-because the topic is used in both the application client and the EJB
+because the topic is used in both the application client and the Jakarta Enterprise Beans
 module
 2.  Injects `ConnectionFactory` and `Topic` resources
 3.  Creates a `TemporaryQueue` to receive notification of processing
@@ -187,7 +187,7 @@ Coding the Entity Class for the clientmdbentity Example
 
 The `SetupOffice.java` class, also under `clientmdbentity-ejb`, is an
 entity class. The entity and the message-driven beans are packaged
-together in an EJB JAR file. The entity class is declared as follows:
+together in an enterprise bean JAR file. The entity class is declared as follows:
 
 [source,oac_no_warn]
 ----
@@ -283,7 +283,7 @@ This command creates the following:
 ** An application client JAR file that contains the client class and
 listener class files, along with a manifest file that specifies the main
 class
-** An EJB JAR file that contains the message-driven beans and the entity
+** An enterprise bean JAR file that contains the message-driven beans and the entity
 class, along with the `persistence.xml` file
 ** An application EAR file that contains the two JAR files along with an
 `application.xml` file
@@ -322,7 +322,7 @@ This command creates the following:
 ** An application client JAR file that contains the client class and
 listener class files, along with a manifest file that specifies the main
 class
-** An EJB JAR file that contains the message-driven beans and the entity
+** An enterprise bean JAR file that contains the message-driven beans and the entity
 class, along with the `persistence.xml` file
 ** An application EAR file that contains the two JAR files along with an
 `application.xml` file

--- a/src/main/jbake/content/jms-examples010.adoc
+++ b/src/main/jbake/content/jms-examples010.adoc
@@ -1,24 +1,24 @@
 type=page
 status=published
-title=Using NetBeans IDE to Create JMS Resources
+title=Using NetBeans IDE to Create Jakarta Messaging Resources
 next=partsecurity.html
 prev=jms-examples009.html
 ~~~~~~
-Using NetBeans IDE to Create JMS Resources
+Using NetBeans IDE to Create Jakarta Messaging Resources
 ==========================================
 
 [[BABDFDJC]][[using-netbeans-ide-to-create-jms-resources]]
 
-Using NetBeans IDE to Create JMS Resources
+Using NetBeans IDE to Create Jakarta Messaging Resources
 ------------------------------------------
 
-When you write your own JMS applications, you will need to create
+When you write your own Messaging applications, you will need to create
 resources for them. This section explains how to use NetBeans IDE to
 create `src/main/setup/glassfish-resources.xml` files similar to those
 used in the examples in this chapter. It also explains how to use
 NetBeans IDE to delete the resources.
 
-You can also create, list, and delete JMS resources using the
+You can also create, list, and delete Jakarta Messaging resources using the
 Administration Console or the `asadmin create-jms-resource`,
 `asadmin list-jms-resources`, and `asadmin delete-jms-resources`
 commands. For information, consult the GlassFish Server documentation or
@@ -26,15 +26,15 @@ enter `asadmin help` command-name.
 
 The following topics are addressed here:
 
-* link:#CHDFIJBJ[To Create JMS Resources Using NetBeans IDE]
-* link:#CHDCFADI[To Delete JMS Resources Using NetBeans IDE]
+* link:#CHDFIJBJ[To Create Jakarta Messaging Resources Using NetBeans IDE]
+* link:#CHDCFADI[To Delete Jakarta Messaging Resources Using NetBeans IDE]
 
 [[CHDFIJBJ]][[to-create-jms-resources-using-netbeans-ide]]
 
-To Create JMS Resources Using NetBeans IDE
+To Create Jakarta Messaging Resources Using NetBeans IDE
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Follow these steps to create a JMS resource in GlassFish Server using
+Follow these steps to create a Jakarta Messaging resource in GlassFish Server using
 NetBeans IDE. Repeat these steps for each resource you need.
 
 1.  Right-click the project for which you want to create resources and
@@ -44,7 +44,7 @@ select New, then select Other.
 4.  On the General Attributes - JMS Resource page, in the JNDI Name
 field, enter the name of the resource.
 +
-By convention, JMS resource names begin with `jms/`.
+By convention, Messaging resource names begin with `jms/`.
 5.  Select the option for the resource type.
 +
 Normally, this is either `javax.jms.Queue`, `javax.jms.Topic`, or
@@ -67,7 +67,7 @@ Server.
 
 [[CHDCFADI]][[to-delete-jms-resources-using-netbeans-ide]]
 
-To Delete JMS Resources Using NetBeans IDE
+To Delete Jakarta Messaging Resources Using NetBeans IDE
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1.  In the Services tab, expand the Servers node, then expand the

--- a/src/main/jbake/content/jms-examples010.adoc
+++ b/src/main/jbake/content/jms-examples010.adoc
@@ -10,7 +10,7 @@ Using NetBeans IDE to Create Jakarta Messaging Resources
 [[BABDFDJC]][[using-netbeans-ide-to-create-jms-resources]]
 
 Using NetBeans IDE to Create Jakarta Messaging Resources
----------------------------------------------------------
+--------------------------------------------------------
 
 When you write your own Messaging applications, you will need to create
 resources for them. This section explains how to use NetBeans IDE to

--- a/src/main/jbake/content/jms-examples010.adoc
+++ b/src/main/jbake/content/jms-examples010.adoc
@@ -5,12 +5,12 @@ next=partsecurity.html
 prev=jms-examples009.html
 ~~~~~~
 Using NetBeans IDE to Create Jakarta Messaging Resources
-==========================================
+========================================================
 
 [[BABDFDJC]][[using-netbeans-ide-to-create-jms-resources]]
 
 Using NetBeans IDE to Create Jakarta Messaging Resources
-------------------------------------------
+---------------------------------------------------------
 
 When you write your own Messaging applications, you will need to create
 resources for them. This section explains how to use NetBeans IDE to
@@ -32,7 +32,7 @@ The following topics are addressed here:
 [[CHDFIJBJ]][[to-create-jms-resources-using-netbeans-ide]]
 
 To Create Jakarta Messaging Resources Using NetBeans IDE
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Follow these steps to create a Jakarta Messaging resource in GlassFish Server using
 NetBeans IDE. Repeat these steps for each resource you need.
@@ -68,7 +68,7 @@ Server.
 [[CHDCFADI]][[to-delete-jms-resources-using-netbeans-ide]]
 
 To Delete Jakarta Messaging Resources Using NetBeans IDE
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1.  In the Services tab, expand the Servers node, then expand the
 GlassFish Server node.


### PR DESCRIPTION
I took the liberty to use "Messaging" in place of "Jakarta Messaging" in a lot of places to reduce verbosity. This is in line with the use of "enterprise beans" that was already there.

Going forward, I think we'll better use generic terms such as "messaging" or "transactions" in these non normative texts to make texts more user friendly.