### PR TITLE
Fix typo "https://github.com/eclipse-ee4j/jakartaee-tutorial/issues/184"

### DIFF
--- a/src/main/jbake/content/ejb-gettingstarted003.adoc
+++ b/src/main/jbake/content/ejb-gettingstarted003.adoc
@@ -9,9 +9,6 @@ Modifying the Jakarta EE Application
 
 [[GIPTI]][[modifying-the-jakarta-ee-application]]
 
-Modifying the Jakarta EE Application
-------------------------------------
-
 GlassFish Server supports iterative development. Whenever you make a
 change to a Jakarta EE application, you must redeploy the application.
 


### PR DESCRIPTION
Fixed small type 