### PR TITLE
Update action, disable deploy step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,12 @@ jobs:
     - name: Build Docs
       run: mvn clean package --file pom.xml #-Ppublish-site 
       
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@3.7.1
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages # The branch the action should deploy to.
-        FOLDER: target/generated-docs # The folder the action should deploy.
-        CLEAN: true # Automatically remove deleted files from the deploy br  
+#    - name: Deploy 🚀
+#      uses: JamesIves/github-pages-deploy-action@3.7.1
+#      with:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        BRANCH: gh-pages # The branch the action should deploy to.
+#        FOLDER: target/generated-docs # The folder the action should deploy.
+#        CLEAN: true # Automatically remove deleted files from the deploy br  
        
 


### PR DESCRIPTION
I don't think it should deploy directly from every commit to master. There is a jenkins job that deploys from a release tag, https://ci.eclipse.org/jakartaee-platform/job/tutorial-publish/