### PR TITLE
Porting Jakarta EE Tutorial from '9.1' to '10'. Jakarta Faces. Rename JSF to Faces over all place. 'jsf.ajax.* become faces.ajax.*' (https://github.com/jakartaee/faces/issues/1552)

### DIFF
--- a/src/main/asciidoc/jsf-ajax/jsf-ajax003.adoc
+++ b/src/main/asciidoc/jsf-ajax/jsf-ajax003.adoc
@@ -6,7 +6,7 @@ This built-in Ajax resource can be used in Jakarta Faces web applications in one
 * By using the `f:ajax` tag along with another standard component in a Facelets application.
 This method adds Ajax functionality to any UI component without additional coding and configuration.
 
-* By using the JavaScript API method `jsf.ajax.request()` directly within the Facelets application.
+* By using the JavaScript API method `faces.ajax.request()` directly within the Facelets application.
 This method provides direct access to Ajax methods and allows customized control of component behavior.
 
 * By using the `<h:commandScript>` component to execute arbitrary server-side methods from a view.

--- a/src/main/asciidoc/jsf-ajax/jsf-ajax004.adoc
+++ b/src/main/asciidoc/jsf-ajax/jsf-ajax004.adoc
@@ -7,7 +7,7 @@ The application uses the attributes of the `f:ajax` tag listed in <<attributes-o
 The following sections explain the process of creating and sending an Ajax request using some of these attributes.
 
 [NOTE]
-Behind the scenes, the `jsf.ajax.request()` method of the JavaScript resource library collects the data provided by the `f:ajax` tag and posts the request to the Jakarta Faces lifecycle.
+Behind the scenes, the `faces.ajax.request()` method of the JavaScript resource library collects the data provided by the `f:ajax` tag and posts the request to the Jakarta Faces lifecycle.
 
 === Using the event Attribute
 

--- a/src/main/asciidoc/jsf-ajax/jsf-ajax007.adoc
+++ b/src/main/asciidoc/jsf-ajax/jsf-ajax007.adoc
@@ -18,7 +18,7 @@ In the following example, the `render` attribute identifies an output component 
 ----
 
 [NOTE]
-Behind the scenes, once again the `jsf.ajax.request()` method handles the response.
+Behind the scenes, once again the `faces.ajax.request()` method handles the response.
 It registers a response-handling callback when the original request is created.
 When the response is sent back to the client, the callback is invoked.
 This callback automatically updates the client-side DOM to reflect the rendered response.

--- a/src/main/asciidoc/jsf-ajax/jsf-ajax010.adoc
+++ b/src/main/asciidoc/jsf-ajax/jsf-ajax010.adoc
@@ -42,13 +42,13 @@ For example, consider the following:
     <h:inputText id="inputname" value="#{userBean.name}"/>
     <h:outputText id="outputname" value="#{userBean.name}"/>
     <h:commandButton id="submit" value="Submit"
-                     onclick="jsf.ajax.request(this, event,
+                     onclick="faces.ajax.request(this, event,
                               {execute:'inputname',render:'outputname'});
                               return false;" />
 </h:form>
 ----
 +
-The `jsf.ajax.request` method takes up to three parameters that specify source, event, and options.
+The `faces.ajax.request` method takes up to three parameters that specify source, event, and options.
 The source parameter identifies the DOM element that triggered the Ajax request, typically `this`.
 The optional event parameter identifies the DOM event that triggered this request.
 The optional options parameter contains a set of name/value pairs from <<possible-values-for-the-options-parameter>>.
@@ -80,7 +80,7 @@ Use the `jakarta.faces.application.ResourceDependency` annotation to cause the b
 
 To load the Ajax resource from the server side:
 
-. Use the `jsf.ajax.request` method within the bean class.
+. Use the `faces.ajax.request` method within the bean class.
 +
 [NOTE]
 This method is usually used when creating a custom component or a custom renderer for a component.

--- a/src/main/asciidoc/jsf-ajax/jsf-ajax012.adoc
+++ b/src/main/asciidoc/jsf-ajax/jsf-ajax012.adoc
@@ -3,6 +3,6 @@
 For more information on Ajax in Jakarta Faces Technology, see
 
 * Jakarta Faces project website: +
-https://jakarta.ee/specifications/faces/3.0/[^]
+https://jakarta.ee/specifications/faces/4.0/[^]
 
 * https://jakarta.ee/specifications/faces/3.0/jsdoc/jsf.ajax.html[Jakarta Faces JavaScript Library APIs^]


### PR DESCRIPTION
Before commit and push I'he:
1) synchronized with your changes,
2) generated specification on my PC
3) controlled generated specification.

All seems OK. Let me know if you have problems and/or observations.

Dmitri.
Signed-off-by: Dmitri Cherkas <dmitricerkas@yahoo.com>