### PR TITLE
Porting Jakarta EE Tutorial from '9.1' to '10'. Jakarta Faces. Faces 4.0: "Rename xmlns.jcp.org taglib URIs" (https://github.com/jakartaee/faces/issues/1553)

### DIFF
--- a/src/main/asciidoc/cdi-basicexamples/cdi-basicexamples002.adoc
+++ b/src/main/asciidoc/cdi-basicexamples/cdi-basicexamples002.adoc
@@ -31,8 +31,8 @@ The template page, `template.xhtml`, looks like this:
           "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+      xmlns:h="jakarta.faces.html"
+      xmlns:ui="jakarta.faces.facelets">
     <h:head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <h:outputStylesheet library="css" name="default.css"/>
@@ -66,8 +66,8 @@ The template page, `template.xhtml`, looks like this:
           "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html">
     <ui:composition template="/template.xhtml">
 
         <ui:define name="title">Simple Greeting</ui:define>

--- a/src/main/asciidoc/cdi-basicexamples/cdi-basicexamples003.adoc
+++ b/src/main/asciidoc/cdi-basicexamples/cdi-basicexamples003.adoc
@@ -248,8 +248,8 @@ The `index.xhtml` file, however, is more complex.
           "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html">
     <ui:composition template="/template.xhtml">
 
         <ui:define name="title">Guess My Number</ui:define>

--- a/src/main/asciidoc/ejb-basicexamples/ejb-basicexamples003.adoc
+++ b/src/main/asciidoc/ejb-basicexamples/ejb-basicexamples003.adoc
@@ -319,8 +319,8 @@ Here is the content of `index.xhtml`:
 ----
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html">
     <ui:composition template="/template.xhtml">
         <ui:define name="title">
             This page has been accessed #{count.hitCount} time(s).

--- a/src/main/asciidoc/jsf-custom/faces-custom010.adoc
+++ b/src/main/asciidoc/jsf-custom/faces-custom010.adoc
@@ -12,9 +12,9 @@ The `ui:composition` tag on the `index.xhtml` page declares the namespace define
 [source,xml]
 ----
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-                xmlns:h="http://xmlns.jcp.org/jsf/html"
-                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ui="jakarta.faces.facelets"
+                xmlns:h="jakarta.faces.html"
+                xmlns:f="jakarta.faces.core"
                 xmlns:bookstore="http://dukesbookstore"
                 template="./bookstoreTemplate.xhtml">
 ----

--- a/src/main/asciidoc/jsf-facelets/jsf-facelets001.adoc
+++ b/src/main/asciidoc/jsf-facelets/jsf-facelets001.adoc
@@ -39,11 +39,11 @@ To support the Jakarta Faces tag library mechanism, Facelets uses XML namespace 
 |===
 |Tag Library |URI |Prefix |Example |Contents
 
-|Jakarta Faces Facelets Tag Library |\http://xmlns.jcp.org/jsf/facelets |`ui:` | `ui:component`
+|Jakarta Faces Facelets Tag Library |jakarta.faces.facelets |`ui:` | `ui:component`
 
 `ui:insert` |Tags for templating
 
-|Jakarta Faces HTML Tag Library |\http://xmlns.jcp.org/jsf/html |`h:` |`h:head`
+|Jakarta Faces HTML Tag Library |jakarta.faces.html |`h:` |`h:head`
 
 `h:body`
 
@@ -51,15 +51,15 @@ To support the Jakarta Faces tag library mechanism, Facelets uses XML namespace 
 
 `h:inputText` |Jakarta Faces component tags for all `UIComponent` objects
 
-|Jakarta Faces Core Tag Library |\http://xmlns.jcp.org/jsf/core |`f:` | `f:actionListener`
+|Jakarta Faces Core Tag Library |jakarta.faces.core |`f:` | `f:actionListener`
 
 `f:attribute` |Tags for Jakarta Faces custom actions that are independent of any particular render kit
 
-|Pass-through Elements Tag Library |\http://xmlns.jcp.org/jsf |`faces:` |`faces:id` |Tags to support HTML5-friendly markup
+|Pass-through Elements Tag Library |jakarta.faces |`faces:` |`faces:id` |Tags to support HTML5-friendly markup
 
-|Pass-through Attributes Tag Library |\http://xmlns.jcp.org/jsf/passthrough |`p:` |`p:type` |Tags to support HTML5-friendly markup
+|Pass-through Attributes Tag Library |jakarta.faces.passthrough |`p:` |`p:type` |Tags to support HTML5-friendly markup
 
-|Composite Component Tag Library |\http://xmlns.jcp.org/jsf/composite |`cc:` |`cc:interface` |Tags to support composite components
+|Composite Component Tag Library |jakarta.faces.composite |`cc:` |`cc:interface` |Tags to support composite components
 
 |JSTL Core Tag Library |\http://xmlns.jcp.org/jsp/jstl/core |`c:` |`c:forEach`
 
@@ -81,13 +81,13 @@ As is always the case when you declare an XML namespace, you can specify any pre
 For example, you can declare the prefix for the composite component tag library as
 
 ----
-xmlns:composite="http://xmlns.jcp.org/jsf/composite"
+xmlns:composite="jakarta.faces.composite"
 ----
 
 instead of as
 
 ----
-xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+xmlns:cc="jakarta.faces.composite"
 ----
 
 Based on the Jakarta Faces support for Expression Language (EL) syntax, Facelets uses EL expressions to reference properties and methods of managed beans.

--- a/src/main/asciidoc/jsf-facelets/jsf-facelets003.adoc
+++ b/src/main/asciidoc/jsf-facelets/jsf-facelets003.adoc
@@ -114,8 +114,8 @@ The next section specifies the language of the XHTML page and then declares the 
 ----
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 ----
 
 The next section uses various tags to insert components into the web page:
@@ -180,7 +180,7 @@ You can now create the second page, `response.xhtml`, with the following content
 
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:h="jakarta.faces.html">
 
     <h:head>
         <h:outputStylesheet library="css" name="default.css"/>

--- a/src/main/asciidoc/jsf-facelets/jsf-facelets004.adoc
+++ b/src/main/asciidoc/jsf-facelets/jsf-facelets004.adoc
@@ -50,8 +50,8 @@ Here is an example of a template saved as `template.xhtml`:
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html">
 
     <h:head>
         <meta http-equiv="Content-Type"
@@ -90,8 +90,8 @@ A client page allows content to be inserted with the help of the `ui:define` tag
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:ui="jakarta.faces.facelets"
+      xmlns:h="jakarta.faces.html">
 
     <h:body>
         <ui:composition template="./template.xhtml">

--- a/src/main/asciidoc/jsf-facelets/jsf-facelets005.adoc
+++ b/src/main/asciidoc/jsf-facelets/jsf-facelets005.adoc
@@ -47,8 +47,8 @@ The following example shows a composite component that accepts an email address 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-  xmlns:composite="http://xmlns.jcp.org/jsf/composite"
-  xmlns:h="http://xmlns.jcp.org/jsf/html">
+  xmlns:composite="jakarta.faces.composite"
+  xmlns:h="jakarta.faces.html">
 
     <h:head>
         <title>This content will not be displayed</title>
@@ -81,8 +81,8 @@ The using page includes a reference to the composite component, in the `xml` nam
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-  xmlns:h="http://xmlns.jcp.org/jsf/html"
-  xmlns:em="http://xmlns.jcp.org/jsf/composite/emcomp">
+  xmlns:h="jakarta.faces.html"
+  xmlns:em="jakarta.faces.composite/emcomp">
 
     <h:head>
         <title>Using a sample composite component</title>
@@ -96,7 +96,7 @@ The using page includes a reference to the composite component, in the `xml` nam
 </html>
 ----
 
-The local composite component library is defined in the `xmlns` namespace with the declaration `xmlns:em="http://xmlns.jcp.org/jsf/composite/emcomp"`.
+The local composite component library is defined in the `xmlns` namespace with the declaration `xmlns:em="jakarta.faces.composite.emcomp"`.
 The component itself is accessed through the `em:email` tag.
 The preceding example content can be stored as a web page named `emuserpage.xhtml` under the web root directory.
 When compiled and deployed on a server, it can be accessed with the following URL:

--- a/src/main/asciidoc/jsf-facelets/jsf-facelets009.adoc
+++ b/src/main/asciidoc/jsf-facelets/jsf-facelets009.adoc
@@ -21,12 +21,12 @@ You can mix and match Jakarta Faces and HTML5 components and elements as you see
 
 Pass-through elements allow you to use HTML5 tags and attributes but to treat them as equivalent to Jakarta Faces components associated with a server-side `UIComponent` instance.
 
-To make an element that is not a Jakarta Faces element a pass-through element, specify at least one of its attributes using the `\http://xmlns.jcp.org/jsf` namespace.
+To make an element that is not a Jakarta Faces element a pass-through element, specify at least one of its attributes using the `jakarta.faces` namespace.
 For example, the following code declares the namespace with the short name `jsf`:
 
 [source,xml]
 ----
-<html ... xmlns:faces="http://xmlns.jcp.org/jsf"
+<html ... xmlns:faces="jakarta.faces"
 ...
     <input type="email" faces:id="email" name="email"
            value="#{reservationBean.email}" required="required"/>
@@ -130,7 +130,7 @@ For example, the following code declares the namespace with the short name `p`, 
 +
 [source,xml]
 ----
-<html ... xmlns:p="http://xmlns.jcp.org/jsf/passthrough"
+<html ... xmlns:p="jakarta.faces.passthrough"
 ...
 
 <h:form prependId="false">
@@ -218,10 +218,10 @@ The namespace declarations in the `html` element of the `reservation.xhtml` page
 ----
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://xmlns.jcp.org/jsf/passthrough"
-      xmlns:faces="http://xmlns.jcp.org/jsf">
+      xmlns:f="jakarta.faces.core"
+      xmlns:h="jakarta.faces.html"
+      xmlns:p="jakarta.faces.passthrough"
+      xmlns:faces="jakarta.faces">
 ----
 
 Next, an empty `h:head` tag followed by an `h:outputStylesheet` tag within the `h:body` tag illustrates the use of a relocatable resource (as described in <<relocatable-resources>>):

--- a/src/main/asciidoc/jsf-page/jsf-page001.adoc
+++ b/src/main/asciidoc/jsf-page/jsf-page001.adoc
@@ -23,8 +23,8 @@ For example, when you create a Facelets XHTML page, include namespace directives
 [source,xml]
 ----
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core">
 ----
 
 The XML namespace URI identifies the tag library location, and the prefix value is used to distinguish the tags belonging to that specific tag library.

--- a/src/main/asciidoc/jsf-page/jsf-page002.adoc
+++ b/src/main/asciidoc/jsf-page/jsf-page002.adoc
@@ -236,7 +236,7 @@ The following is an example of an XHTML page using `h:head` and `h:body` tags:
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <h:head>
         Add a title
     </h:head>
@@ -1308,7 +1308,7 @@ Here is an example:
 [source,xml]
 ----
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <h:head id="head">
         <title>Resource Relocation</title>
     </h:head>
@@ -1350,7 +1350,7 @@ Here is an example:
 [source,xml]
 ----
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <h:head id="head">
         <title>Resource Relocation</title>
     </h:head>

--- a/src/main/asciidoc/webapp/webapp003.adoc
+++ b/src/main/asciidoc/webapp/webapp003.adoc
@@ -31,7 +31,7 @@ For this application, the page uses simple tag markup to display a form with a g
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <h:head>
         <title>Facelets Hello Greeting</title>
     </h:head>
@@ -79,7 +79,7 @@ The response page appears.Even simpler than the greeting page, the response page
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <h:head>
         <title>Facelets Hello Response</title>
     </h:head>


### PR DESCRIPTION
Generated on my PC and verified before commit.

Dmitri.

Signed-off-by: Dmitri Cherkas <dmitricerkas@yahoo.com>