### PR TITLE
Porting Jakarta EE Tutorial from '9.1' to '10'. Jakarta Faces. Faces 4.0: "Rename 'http://xmlns.jcp.org/jsf/*' URL to 'jakarta.faces.*' URN ((https://github.com/jakartaee/faces/issues/1553))

### DIFF
--- a/src/main/asciidoc/cdi-adv-examples/cdi-adv-examples002.adoc
+++ b/src/main/asciidoc/cdi-adv-examples/cdi-adv-examples002.adoc
@@ -59,7 +59,7 @@ The simple Facelets page for the `encoder` example, `index.xhtml`, asks the user
 ----
 <html lang="en"
       xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html">
+      xmlns:h="jakarta.faces.html">
     <h:head>
         <h:outputStylesheet library="css" name="default.css"/>
         <title>String Encoder</title>

--- a/src/main/asciidoc/jsf-facelets/jsf-facelets001.adoc
+++ b/src/main/asciidoc/jsf-facelets/jsf-facelets001.adoc
@@ -61,11 +61,11 @@ To support the Jakarta Faces tag library mechanism, Facelets uses XML namespace 
 
 |Composite Component Tag Library |jakarta.faces.composite |`cc:` |`cc:interface` |Tags to support composite components
 
-|JSTL Core Tag Library |\http://xmlns.jcp.org/jsp/jstl/core |`c:` |`c:forEach`
+|JSTL Core Tag Library |jakarta.tags.core |`c:` |`c:forEach`
 
 `c:catch` |JSTL 1.2 Core Tags
 
-|JSTL Functions Tag Library |\http://xmlns.jcp.org/jsp/jstl/functions |`fn:` |`fn:toUpperCase`
+|JSTL Functions Tag Library |jakarta.tags.functions |`fn:` |`fn:toUpperCase`
 
 `fn:toLowerCase` |JSTL 1.2 Functions Tags
 |===


### PR DESCRIPTION
Generated on my PC and verified before commit.

Dmitri.

Signed-off-by: Dmitri Cherkas <dmitricerkas@yahoo.com>