### PR TITLE
Small corrections in "A Web Module That Uses Jakarta Servlet Technology: The hello2 Example" section.

### DIFF
--- a/src/main/asciidoc/webapp/webapp004.adoc
+++ b/src/main/asciidoc/webapp/webapp004.adoc
@@ -138,7 +138,7 @@ public class ResponseServlet extends HttpServlet {
 
 You can use either NetBeans IDE or Maven to build, package, deploy, and run the `hello2` example.
 
-==== To Run the hello2 Example Using NetBeans IDE
+==== To Build, Package, Deploy and Run the hello2 Example Using NetBeans IDE
 
 To run the `hello2` example using NetBeans IDE:
 
@@ -169,7 +169,7 @@ The URL specifies the context root, followed by the URL pattern.
 The application looks much like the `hello1` application.
 The major difference is that after you click Submit the response appears below the greeting, not on a separate page.
 
-==== To Run the hello2 Example Using Maven
+====  To Build, Package, Deploy and Run the hello2 Example Using Maven
 
 To run the `hello2` example using Maven:
 

--- a/src/main/asciidoc/webapp/webapp004.adoc
+++ b/src/main/asciidoc/webapp/webapp004.adoc
@@ -140,7 +140,7 @@ You can use either NetBeans IDE or Maven to build, package, deploy, and run the 
 
 ==== To Build, Package, Deploy and Run the hello2 Example Using NetBeans IDE
 
-To run the `hello2` example using NetBeans IDE:
+To build, package, deploy and run the `hello2` example using NetBeans IDE:
 
 . Start GlassFish Server as described in <<to-start-glassfish-server-using-netbeans-ide>>, if you have not already done so.
 
@@ -171,7 +171,7 @@ The major difference is that after you click Submit the response appears below t
 
 ====  To Build, Package, Deploy and Run the hello2 Example Using Maven
 
-To run the `hello2` example using Maven:
+To build, package, deploy and run the `hello2` example using Maven:
 
 . Start GlassFish Server as described in <<to-start-glassfish-server-using-the-command-line>>, if you have not already done so.
 


### PR DESCRIPTION
Hello,

if you look at the:
 
1) "_To Run the hello2 Example Using NetBeans IDE_" (https://eclipse-ee4j.github.io/jakartaee-tutorial/#to-run-the-hello2-example-using-netbeans-ide)
2) and "_To Run the hello2 Example Using Maven_" (https://eclipse-ee4j.github.io/jakartaee-tutorial/#to-run-the-hello2-example-using-maven)

paragraphs, you can see that those paragraphs describe non only Running "hello2 example", but also steps to build, package and deploy it. 

In fact, if you look at:

3) "_To Build and Package the hello1 Web Module Using NetBeans IDE_" (https://eclipse-ee4j.github.io/jakartaee-tutorial/#to-build-and-package-the-hello1-web-module-using-netbeans-ide)
4) and "_To Build and Package the hello1 Web Module Using Maven_" (https://eclipse-ee4j.github.io/jakartaee-tutorial/#to-build-and-package-the-hello1-web-module-using-maven)

paragraphs of the "_Packaging and Deploying the hello1 Web Module_" (https://eclipse-ee4j.github.io/jakartaee-tutorial/#packaging-and-deploying-the-hello1-web-module) section, you can easily notice that "1)" and "3)", "2)" and "4)" contains the same information.

So I think it would be better to rename:

5)  "_To Run the hello2 Example Using NetBeans IDE_" to "**To Build, Package, Deploy and Run the hello2 Example Using NetBeans IDE**"
6) and "_To Run the hello2 Example Using Maven_" to "**To build, package, deploy and run the `hello2` example using Maven**"

Thank you,
Dmitri.