### PR TITLE
'Chapter 7. Jakarta Faces', paragraph 'User Interface Component Classes': 1) 'ActionSource' is not deprecated, so phrase about deprecation is removed. 2) improve readability proposal

### DIFF
--- a/src/main/asciidoc/faces-intro/faces-intro005.adoc
+++ b/src/main/asciidoc/faces-intro/faces-intro005.adoc
@@ -45,8 +45,22 @@ This component is analogous to the `form` tag in HTML.
 
 * `UIGraphic`: Displays an image.
 
-* `UIInput`: Takes data input from a user.
+* `UIOutput`: Displays data output on a page.
+
+** `UIInput`: Takes data input from a user.
 This class is a subclass of `UIOutput`.
+
+*** `UISelectBoolean`: Allows a user to set a `boolean` value on a control by selecting or deselecting it.
+This class is a subclass of the `UIInput` class.
+
+*** `UISelectMany`: Allows a user to select multiple items from a group of items.
+This class is a subclass of the `UIInput` class.
+
+*** `UISelectOne`: Allows a user to select one item from a group of items.
+This class is a subclass of the `UIInput` class.
+
+*** `UIViewParameter`: Represents the query parameters in a request.
+This class is a subclass of the `UIInput` class.
 
 * `UIMessage`: Displays a localized error message.
 
@@ -54,27 +68,13 @@ This class is a subclass of `UIOutput`.
 
 * `UIOutcomeTarget`: Displays a link in the form of a link or a button.
 
-* `UIOutput`: Displays data output on a page.
-
 * `UIPanel`: Manages the layout of its child components.
 
 * `UIParameter`: Represents substitution parameters.
 
-* `UISelectBoolean`: Allows a user to set a `boolean` value on a control by selecting or deselecting it.
-This class is a subclass of the `UIInput` class.
-
 * `UISelectItem`: Represents a single item in a set of items.
 
 * `UISelectItems`: Represents an entire set of items.
-
-* `UISelectMany`: Allows a user to select multiple items from a group of items.
-This class is a subclass of the `UIInput` class.
-
-* `UISelectOne`: Allows a user to select one item from a group of items.
-This class is a subclass of the `UIInput` class.
-
-* `UIViewParameter`: Represents the query parameters in a request.
-This class is a subclass of the `UIInput` class.
 
 * `UIViewRoot`: Represents the root of the component tree.
 
@@ -85,7 +85,7 @@ These behavioral interfaces, all defined in the `jakarta.faces.component` packag
 * `ActionSource`: Indicates that the component can fire an action event.
 This interface is intended for use with components based on JavaServer Faces technology 1.1_01 and earlier versions.
 
-* `ActionSource2`: Extends `ActionSource` and therefore provides the same functionality.
+** `ActionSource2`: Extends `ActionSource` and therefore provides the same functionality.
 However, it allows components to use the Expression Language (EL) when they are referencing methods that handle action events.
 
 * `EditableValueHolder`: Extends `ValueHolder` and specifies additional features for editable components, such as validation and emitting value-change events.

--- a/src/main/asciidoc/faces-intro/faces-intro005.adoc
+++ b/src/main/asciidoc/faces-intro/faces-intro005.adoc
@@ -84,7 +84,6 @@ These behavioral interfaces, all defined in the `jakarta.faces.component` packag
 
 * `ActionSource`: Indicates that the component can fire an action event.
 This interface is intended for use with components based on JavaServer Faces technology 1.1_01 and earlier versions.
-This interface is deprecated in JavaServer Faces 2.
 
 * `ActionSource2`: Extends `ActionSource` and therefore provides the same functionality.
 However, it allows components to use the Expression Language (EL) when they are referencing methods that handle action events.


### PR DESCRIPTION
Hello,

if you look at the "_User Interface Component Classes_" paragraph (https://eclipse-ee4j.github.io/jakartaee-tutorial/#user-interface-component-classes), you can read:

"
_These behavioral interfaces, all defined in the jakarta.faces.component package unless otherwise stated, are as follows._

_ActionSource: Indicates that the component can fire an action event. This interface is intended for use with components based on JavaServer Faces technology 1.1_01 and earlier versions. **This interface is deprecated in JavaServer Faces 2.**_
" 

but if you exam the API Javadoc of the "ActionSource" interface (https://jakarta.ee/specifications/faces/4.0/apidocs/jakarta/faces/component/actionsource), you can see that the interface is not deprecated (it was not deprecated even in Jakarta Faces 3.0 (was deprecated some methods, but not the entire interface)). 

So I removed the phrase about deprecation.

Thank you,
Dmitri.

Signed-off-by: Dmitri Cherkas <dmitricerkas@yahoo.com>