### PR TITLE
Adapt format to the rest of the document. Colon after "one of the following" instead of point.

### DIFF
--- a/src/main/asciidoc/batch-processing/batch-processing001.adoc
+++ b/src/main/asciidoc/batch-processing/batch-processing001.adoc
@@ -119,7 +119,7 @@ run in parallel.
 
 Batch frameworks keep track of a status for every step in a job. The
 status indicates if a step is running or if it has completed. If the
-step has completed, the status indicates one of the following.
+step has completed, the status indicates one of the following:
 
 * The execution of the step was successful.
 * The step was interrupted.

--- a/src/main/asciidoc/ejb-intro/ejb-intro004.adoc
+++ b/src/main/asciidoc/ejb-intro/ejb-intro004.adoc
@@ -194,7 +194,7 @@ or `@Remote`, and if the bean class does not specify the interface using
 interface.
 
 To build an enterprise bean that allows only local access, you may, but
-are not required to, do one of the following.
+are not required to, do one of the following:
 
 * Create an enterprise bean implementation class that does not implement
 a business interface, indicating that the bean exposes a no-interface

--- a/src/main/asciidoc/jsf-custom/jsf-custom011.adoc
+++ b/src/main/asciidoc/jsf-custom/jsf-custom011.adoc
@@ -187,7 +187,7 @@ class.
 === Using a Custom Converter
 
 To apply the data conversion performed by a custom converter to a
-particular component's value, you must do one of the following.
+particular component's value, you must do one of the following:
 
 * Reference the converter from the component tag's `converter`
 attribute.
@@ -234,7 +234,7 @@ Instead of referencing the converter from the component tag's
 `converter` attribute, you can reference the converter from an
 `f:converter` tag nested inside the component's tag. To reference the
 custom converter using the `f:converter` tag, you do one of the
-following.
+following:
 
 * Set the `f:converter` tag's `converterId` attribute to the `Converter`
 implementation's identifier defined in the `@FacesConverter` annotation

--- a/src/main/asciidoc/jsf-custom/jsf-custom012.adoc
+++ b/src/main/asciidoc/jsf-custom/jsf-custom012.adoc
@@ -194,7 +194,7 @@ Restoring State] for more information.
 
 If you implemented a `Validator` interface rather than implementing a
 managed bean method that performs the validation, you need to do one of
-the following.
+the following:
 
 * Allow the page author to specify the `Validator` implementation to use
 with the `f:validator` tag. In this case, the `Validator` implementation
@@ -232,7 +232,7 @@ validator tag on the page.
 === Using a Custom Validator
 
 To register a custom validator on a component, you must do one of the
-following.
+following:
 
 * Nest the validator's custom tag inside the tag of the component whose
 value you want to be validated.
@@ -267,7 +267,7 @@ developer will not create a custom tag for use with the validator.
 
 In this case, the page author must nest the `f:validator` tag inside the
 tag of the component whose data needs to be validated. Then the page
-author needs to do one of the following.
+author needs to do one of the following:
 
 * Set the `f:validator` tag's `validatorId` attribute to the ID of the
 validator that is defined in the application configuration resource

--- a/src/main/asciidoc/jsf-facelets/jsf-facelets006.adoc
+++ b/src/main/asciidoc/jsf-facelets/jsf-facelets006.adoc
@@ -5,7 +5,7 @@
 Web resources are any software artifacts that the web application
 requires for proper rendering, including images, script files, and any
 user-created component libraries. Resources must be collected in a
-standard location, which can be one of the following.
+standard location, which can be one of the following:
 
 * A resource packaged in the web application root must be in a
 subdirectory of a `resources` directory at the web application root:


### PR DESCRIPTION
Hello,

if you look in the tutorial, you can see that in some cases after the phrase "one of the following" there is a colon (8 occurences), and in some cases (also 8 occurences) - a point.

I think the colon is more appropriate.

Thank you,
Dmitri.