### PR TITLE
Unclosed tag problem in the "faces-facelets009.adoc".

### DIFF
--- a/src/main/asciidoc/jsf-facelets/jsf-facelets009.adoc
+++ b/src/main/asciidoc/jsf-facelets/jsf-facelets009.adoc
@@ -165,7 +165,7 @@ within a component tag, specifying an EL value that must evaluate to a
 +
 [source,xml]
 ----
-<h:inputText value="#{bean.nights">
+<h:inputText value="#{bean.nights}">
     <f:passThroughAttributes value="#{bean.nameValuePairs}" />
 </h:inputText>
 ----


### PR DESCRIPTION
On the page "https://jakartaee.github.io/jakartaee-documentation/jakartaee-tutorial/9.1/web/faces-facelets/faces-facelets.html" seems to be the following unclosed tag: "<h:inputText value="#{bean.nights">" (there is "}" missing after "nights").

Thank you!
Dmitri.