### PR TITLE
Fix The tutorial examples repository doesn't exist anymore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,30 +8,30 @@ The Jakarta EE Platform project produces the Jakarta EE
 platform specification, which is an umbrella specification that
 aggregates all other Jakarta EE specifications.
 
-* [https://projects.eclipse.org/projects/ee4j.jakartaee-platform](https://projects.eclipse.org/projects/ee4j.jakartaee-platform)
+- [https://projects.eclipse.org/projects/ee4j.jakartaee-platform](https://projects.eclipse.org/projects/ee4j.jakartaee-platform)
 
 ## Developer resources
 
 Information regarding source code management, builds, coding standards, and
 more.
 
-* [https://projects.eclipse.org/projects/ee4j.jakartaee-platform/developer](https://projects.eclipse.org/projects/ee4j.jakartaee-platform/developer)
+- [https://projects.eclipse.org/projects/ee4j.jakartaee-platform/developer](https://projects.eclipse.org/projects/ee4j.jakartaee-platform/developer)
 
 The project maintains the following source code repositories
 
-* [https://github.com/eclipse-ee4j/jakartaee-platform](https://github.com/eclipse-ee4j/jakartaee-platform)
-* [https://github.com/eclipse-ee4j/jakartaee-tutorial](https://github.com/eclipse-ee4j/jakartaee-tutorial)
-* [https://github.com/eclipse-ee4j/jakartaee-tutorial-examples](https://github.com/eclipse-ee4j/jakartaee-tutorial-examples)
-* [https://github.com/eclipse-ee4j/jakartaee-firstcup](https://github.com/eclipse-ee4j/jakartaee-firstcup)
-* [https://github.com/eclipse-ee4j/jakartaee-firstcup-examples](https://github.com/eclipse-ee4j/jakartaee-firstcup-examples)
-* [https://github.com/eclipse-ee4j/jakartaee-schemas](https://github.com/eclipse-ee4j/jakartaee-schemas)
+- [https://github.com/eclipse-ee4j/jakartaee-platform](https://github.com/eclipse-ee4j/jakartaee-platform)
+- [https://github.com/eclipse-ee4j/jakartaee-tutorial](https://github.com/eclipse-ee4j/jakartaee-tutorial)
+- [https://github.com/eclipse-ee4j/jakartaee-examples](https://github.com/eclipse-ee4j/jakartaee-examples)
+- [https://github.com/eclipse-ee4j/jakartaee-firstcup](https://github.com/eclipse-ee4j/jakartaee-firstcup)
+- [https://github.com/eclipse-ee4j/jakartaee-firstcup-examples](https://github.com/eclipse-ee4j/jakartaee-firstcup-examples)
+- [https://github.com/eclipse-ee4j/jakartaee-schemas](https://github.com/eclipse-ee4j/jakartaee-schemas)
 
 ## Eclipse Contributor Agreement
 
 Before your contribution can be accepted by the project team contributors must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
-* [http://www.eclipse.org/legal/ECA.php](http://www.eclipse.org/legal/ECA.php)
+- [http://www.eclipse.org/legal/ECA.php](http://www.eclipse.org/legal/ECA.php)
 
 Commits that are provided by non-committers must have a Signed-off-by field in
 the footer indicating that the author is aware of the terms by which the
@@ -46,4 +46,4 @@ For more information, please see the Eclipse Committer Handbook:
 
 Contact the project developers via the project's "dev" list.
 
-* [https://accounts.eclipse.org/mailing-list/jakartaee-platform-dev](https://accounts.eclipse.org/mailing-list/jakartaee-platform-dev)
+- [https://accounts.eclipse.org/mailing-list/jakartaee-platform-dev](https://accounts.eclipse.org/mailing-list/jakartaee-platform-dev)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -3,7 +3,7 @@
 This content is produced and maintained by the Jakarta EE Platform
 project.
 
-* Project home: https://projects.eclipse.org/projects/ee4j.jakartaee-platform
+- Project home: https://projects.eclipse.org/projects/ee4j.jakartaee-platform
 
 ## Trademarks
 
@@ -27,12 +27,12 @@ SPDX-License-Identifier: EPL-2.0
 
 The project maintains the following source code repositories:
 
-* https://github.com/eclipse-ee4j/jakartaee-platform
-* https://github.com/eclipse-ee4j/jakartaee-tutorial
-* https://github.com/eclipse-ee4j/jakartaee-tutorial-examples
-* https://github.com/eclipse-ee4j/jakartaee-firstcup
-* https://github.com/eclipse-ee4j/jakartaee-firstcup-examples
-* https://github.com/eclipse-ee4j/jakartaee-schemas
+- https://github.com/eclipse-ee4j/jakartaee-platform
+- https://github.com/eclipse-ee4j/jakartaee-tutorial
+- https://github.com/eclipse-ee4j/jakartaee-examples
+- https://github.com/eclipse-ee4j/jakartaee-firstcup
+- https://github.com/eclipse-ee4j/jakartaee-firstcup-examples
+- https://github.com/eclipse-ee4j/jakartaee-schemas
 
 ## Third-party Content
 
@@ -40,9 +40,9 @@ This project leverages the following third party content.
 
 W3C Documents for JakartaEE Schemas (n/a)
 
-* License: W3C-19980720
-* Project: https://github.com/eclipse-ee4j/jakartaee-schemas
-* Source: http://www.w3.org/2001
+- License: W3C-19980720
+- Project: https://github.com/eclipse-ee4j/jakartaee-schemas
+- Source: http://www.w3.org/2001
 
 ## Cryptography
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 ### Note: This repository is no longer maintained and the project is now moved. To refer to the new project, follow this link: [Jakarta EE Tutorial](https://github.com/jakartaee/jakartaee-tutorial)
+
 # Jakarta EE Tutorial
 
 ![ build](https://github.com/eclipse-ee4j/jakartaee-tutorial/workflows/build/badge.svg)
 
 This repository contains the source files that are used to build the
 _Jakarta Enterprise Edition (Jakarta EE) Tutorial_. The source files
-are authored in [AsciiDoc](http://asciidoc.org/).  AsciiDoc is similar
-to markdown but is particularly suited for user documentation.  
+are authored in [AsciiDoc](http://asciidoc.org/). AsciiDoc is similar
+to markdown but is particularly suited for user documentation.
 
 Note that the Jakarta EE Tutorial code examples are located in a
 separate repository
-[eclipse-ee4j/jakartaee-tutorial-examples](https://github.com/eclipse-ee4j/jakartaee-tutorial-examples).
+[eclipse-ee4j/jakartaee-examples](https://github.com/eclipse-ee4j/jakartaee-examples).
 
 ## Contributing
+
 The easiest way to contribute is by opening an issue in this project
 that contains feedback and review comments.
 
@@ -21,9 +23,9 @@ help is greatly appreciated. If you have an idea for the tutorial and
 want to add a section or update an existing section, then review the
 following links:
 
-* [Contribute](CONTRIBUTING.md)
-* [Pull Request Acceptance Workflow](src/main/jbake/assets/pr_doc_workflow.md)
-* [License](LICENSE.md)
+- [Contribute](CONTRIBUTING.md)
+- [Pull Request Acceptance Workflow](src/main/jbake/assets/pr_doc_workflow.md)
+- [License](LICENSE.md)
 
 ## Building the Jakarta EE Tutorial
 
@@ -53,7 +55,6 @@ output.
 mvn generate-resources
 ```
 
-
 ### Deploy the Site to Github Pages
 
 If you want to manually push a build to the gh-pages branch, use:
@@ -61,7 +62,8 @@ If you want to manually push a build to the gh-pages branch, use:
 ```
 mvn deploy -Ppublish-site
 ```
-Never commit changes to the *gh-pages* branch directly.
+
+Never commit changes to the _gh-pages_ branch directly.
 
 ### Produce a Zip File for Download
 

--- a/src/main/asciidoc/usingexamples/usingexamples001.adoc
+++ b/src/main/asciidoc/usingexamples/usingexamples001.adoc
@@ -44,7 +44,7 @@ as-install/bin
 
 === Jakarta EE Tutorial Examples
 
-The tutorial example codes are located at https://github.com/eclipse-ee4j/jakartaee-tutorial-examples.
+The tutorial example codes are located at https://github.com/eclipse-ee4j/jakartaee-examples.
 
 Download the examples and extract it to the following location:
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/jakartaee-tutorial/issues/284